### PR TITLE
Landing hero polish: drop AI-tell pill, fix mobile, name 'Open source', point docs at developer.litprotocol.com

### DIFF
--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -44,8 +44,8 @@ const LandingHero = () => {
         </h1>
         <p className="mt-8 max-w-xl mx-auto text-white/70 text-lg leading-relaxed">
           One programmable runtime. Pulls data from any source, runs your logic
-          inside a chain-secured TEE, signs on any chain or API — with no
-          backend to trust.
+          inside a chain-secured TEE, signs on any chain or API. Open source,
+          no backend to trust.
         </p>
         <div className="mt-10 flex gap-3 justify-center flex-wrap">
           <Button

--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -5,13 +5,6 @@ import { Button } from '../ui/Button';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { CONTACT_FORM, DOCS_LINK } from '@/utils/constants';
 
-const HeroBadge = ({ children }: { children: React.ReactNode }) => (
-  <span className="inline-flex items-center gap-2 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-white/60 border border-white/15 rounded-full px-3 py-1">
-    <span className="w-1.5 h-1.5 rounded-full bg-mint-500" />
-    {children}
-  </span>
-);
-
 const Pillar = ({ label, sub }: { label: string; sub: string }) => (
   <div className="border border-white/10 rounded-xl p-5 bg-white/[0.02] text-left">
     <div className="font-mono text-xs uppercase tracking-[0.2em] text-white/40">
@@ -42,8 +35,7 @@ const LandingHero = () => {
         <img src="/textures/hero-right.png" alt="" className="w-full h-auto" />
       </div>
       <Container size="lg" className="relative z-10 !pt-28 !pb-32 text-center">
-        <HeroBadge>Lit Protocol · TEE-secured compute</HeroBadge>
-        <h1 className="mt-8 text-[2.5rem] md:text-[4.5rem]/[1.05] font-medium tracking-tight max-w-4xl mx-auto">
+        <h1 className="text-[2.5rem] md:text-[4.5rem]/[1.05] font-medium tracking-tight max-w-4xl mx-auto">
           Read anywhere.
           <br />
           <span className="text-mint-500">Compute</span> in a TEE.

--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -35,11 +35,11 @@ const LandingHero = () => {
         <img src="/textures/hero-right.png" alt="" className="w-full h-auto" />
       </div>
       <Container size="lg" className="relative z-10 !pt-28 !pb-32 text-center">
-        <h1 className="text-[2.5rem] md:text-[4.5rem]/[1.05] font-medium tracking-tight max-w-4xl mx-auto">
-          Read anywhere.
-          <br />
-          <span className="text-mint-500">Compute</span> in a TEE.
-          <br />
+        <h1 className="text-[2.5rem]/[1.1] md:text-[4.5rem]/[1.05] font-medium tracking-tight max-w-4xl mx-auto text-balance">
+          Read anywhere.{' '}
+          <br className="hidden md:inline" />
+          <span className="text-mint-500">Compute</span> in a TEE.{' '}
+          <br className="hidden md:inline" />
           Write to any chain or API.
         </h1>
         <p className="mt-8 max-w-xl mx-auto text-white/70 text-lg leading-relaxed">
@@ -67,7 +67,7 @@ const LandingHero = () => {
         </div>
 
         <div className="mt-20 max-w-4xl mx-auto">
-          <div className="grid grid-cols-3 gap-2 md:gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-2 md:gap-4">
             <Pillar label="READ" sub="APIs · RPCs · feeds · prices" />
             <PillarCenter />
             <Pillar label="WRITE" sub="EVM · SVM · BTC · Cosmos · HTTPS" />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 // Resources
-export const DOCS_LINK = 'https://naga.developer.litprotocol.com';
+export const DOCS_LINK = 'https://developer.litprotocol.com';
 export const BANNER_LINK = 'https://x.com/LitProtocol/status/1911850883845149065';
 export const MANIFESTO_LINK =
   'https://spark.litprotocol.com/mass-adoption-of-digital-ownership-and-progressive-self-custody/';


### PR DESCRIPTION
## Summary
- Remove the `LIT PROTOCOL · TEE-secured compute` pill above the hero h1 — it reads as an AI tell.
- Fix the hero on mobile: tighter line-height + `text-balance`, hide the desktop `<br />` breaks below `md:` (they orphaned "API." on its own line at 375px), and stack the READ / COMPUTE / WRITE pillars to one column on mobile (the 3-col grid was cramped at 109px each).
- Mention open source above the fold: hero subhead now ends `...signs on any chain or API. Open source, no backend to trust.`
- Point `DOCS_LINK` at `https://developer.litprotocol.com` (was `naga.developer.litprotocol.com`); picked up by hero CTAs and the footer "Read the docs" button.

## Test plan
- [ ] Hero looks right at 375 / 768 / 1440 px — no orphaned "API.", pillars stack on mobile.
- [ ] "Start building", "Read the docs", and the footer docs link all open `https://developer.litprotocol.com`.