### PR TITLE
Fix broken home-site links and add internal careers page

### DIFF
--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,0 +1,17 @@
+import Layout from '@/components/Layout/Layout';
+import Link from 'next/link';
+
+export default function Careers() {
+  return (
+    <Layout>
+      <article className="legal prose">
+        <h1>Careers</h1>
+        <p>
+          There are no open positions at this time. Check back later for new
+          opportunities.
+        </p>
+        <Link href="/">Return home &#8594;</Link>
+      </article>
+    </Layout>
+  );
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -151,12 +151,7 @@ const Footer = () => {
             </div>
             <div className="flex flex-col gap-3">
               <h6 className={styles.footer__category}>Company</h6>
-              <a
-                href={CAREERS_LINK}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.footer__link}
-              >
+              <a href={CAREERS_LINK} className={styles.footer__link}>
                 Careers
               </a>
               <a

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -56,7 +56,7 @@ const links: LinkItem[] = [
     label: 'Company',
     links: [
       { link: SPARK_LINK, label: 'Blog', external: true },
-      { link: CAREERS_LINK, label: 'Careers', external: true },
+      { link: CAREERS_LINK, label: 'Careers', external: false },
       { link: CONTACT_FORM, label: 'Contact', external: true },
     ],
   },

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -76,12 +76,7 @@ const NavMenu = ({
                 >
                   Blog
                 </a>
-                <a
-                  href={CAREERS_LINK}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.nav__link}
-                >
+                <a href={CAREERS_LINK} className={styles.nav__link}>
                   Careers
                 </a>
                 <a

--- a/src/components/NavMenu/NavMenu2.tsx
+++ b/src/components/NavMenu/NavMenu2.tsx
@@ -44,7 +44,7 @@ const links: LinkItem[] = [
     label: 'Company',
     links: [
       { link: SPARK_LINK, label: 'Blog', external: true },
-      { link: CAREERS_LINK, label: 'Careers', external: true },
+      { link: CAREERS_LINK, label: 'Careers', external: false },
       { link: CONTACT_FORM, label: 'Contact', external: true },
     ],
   },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,12 +11,12 @@ export const CALENDAR_LINK = 'https://litgateway.com/calendar';
 export const GITHUB_LINK = 'https://github.com/LIT-Protocol';
 export const AUDIT_LINK =
   'https://drive.google.com/drive/folders/1Rrht88iUkzpofwl1CvP9gEjqY60BKyFn';
-export const COMMUNITY_LINK = 'https://developer.litprotocol.com/support/intro';
+export const COMMUNITY_LINK = 'https://developer.litprotocol.com/';
 export const VINCENT_LINK = 'https://www.heyvincent.ai/';
 export const DEVELOPER_CONSTANT_LINK = 'https://developer.litprotocol.com';
 export const COMMUNITY_CONSTANT_LINK = 'https://discord.gg/yEJSBaznBX';
 export const COMPANY_CONSTANT_LINK = 'https://litprotocol.com';
-export const GOVERNANCE_LINK = 'https://litprotocol.discourse.group';
+export const GOVERNANCE_LINK = 'https://getlit.dev/chat';
 
 // Product
 export const LIT_WALLET_LINK =
@@ -34,7 +34,7 @@ export const LINKEDIN_LINK = 'https://www.linkedin.com/company/lit-protocol';
 export const GALXE_LINK = 'https://app.galxe.com/quest/LitProtocol';
 
 // Company
-export const CAREERS_LINK = 'https://jobs.litprotocol.com';
+export const CAREERS_LINK = '/careers';
 export const BRAND_LINK = 'https://github.com/LIT-Protocol/Brand-Kit';
 
 // Legal


### PR DESCRIPTION
## Summary
Audited every link on the home site and fixed the three that were broken:
- `COMMUNITY_LINK` (Header/NavMenu "Resources") → `https://developer.litprotocol.com/support/intro` 404s; repointed to `https://developer.litprotocol.com/`.
- `GOVERNANCE_LINK` (Footer "Governance") → `litprotocol.discourse.group` no longer resolves; repointed to the Discord (`getlit.dev/chat`).
- `CAREERS_LINK` (Footer/Header/NavMenu) → `jobs.litprotocol.com` page loads but the account is disabled; replaced with an internal `/careers` page noting no current openings, and dropped `target="_blank"` so it opens in the same tab.

## Test plan
- [ ] Visit `/` and click Community → Resources, Footer → Governance, Footer/Header/Nav → Careers; verify destinations and same-tab behavior for Careers
- [ ] Visit `/careers` directly and confirm "no open positions" copy + return-home link render inside the standard Layout