### PR TITLE
Add /stablecoins — "Provable Compliance" position paper

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://litprotocol.com/sitemap.xml',
+    host: 'https://litprotocol.com',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+const BASE = 'https://litprotocol.com';
+
+// Public routes. Redirect-only paths (e.g. /stablecoins/how-it-works) are excluded.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = '2026-06-01';
+  return [
+    { url: `${BASE}/`, lastModified, changeFrequency: 'weekly', priority: 1 },
+    { url: `${BASE}/stablecoins`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/careers`, lastModified, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE}/legal/privacy-policy`, lastModified, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE}/legal/terms-of-service`, lastModified, changeFrequency: 'yearly', priority: 0.3 },
+  ];
+}

--- a/src/app/stablecoins/_components/Countdown.tsx
+++ b/src/app/stablecoins/_components/Countdown.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// GENIUS Act takes effect Jan 18, 2027 (18 months after the July 18, 2025 signing).
+const TARGET = new Date('2027-01-18T00:00:00-05:00').getTime();
+
+function calc() {
+  const diff = Math.max(0, TARGET - Date.now());
+  return {
+    days: Math.floor(diff / 86_400_000),
+    hours: Math.floor((diff % 86_400_000) / 3_600_000),
+    mins: Math.floor((diff % 3_600_000) / 60_000),
+    secs: Math.floor((diff % 60_000) / 1000),
+  };
+}
+
+const pad = (n: number, len = 2) => String(n).padStart(len, '0');
+
+export default function Countdown({ compact = false }: { compact?: boolean }) {
+  // null until mounted to avoid SSR/client hydration mismatch on a time value
+  const [t, setT] = useState<ReturnType<typeof calc> | null>(null);
+
+  useEffect(() => {
+    setT(calc());
+    const id = setInterval(() => setT(calc()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (compact) {
+    return (
+      <span
+        suppressHydrationWarning
+        className="metric-1 font-mono font-semibold tabular-nums tracking-tight"
+      >
+        {t ? `${t.days} days · ${pad(t.hours)}:${pad(t.mins)}:${pad(t.secs)}` : '— days'}
+      </span>
+    );
+  }
+
+  const units: [string, string][] = [
+    ['Days', t ? pad(t.days, 3) : '000'],
+    ['Hours', t ? pad(t.hours) : '00'],
+    ['Minutes', t ? pad(t.mins) : '00'],
+    ['Seconds', t ? pad(t.secs) : '00'],
+  ];
+
+  return (
+    <div
+      className="flex items-end gap-3 sm:gap-5 md:gap-8 flex-wrap"
+      role="timer"
+      aria-label="Countdown to GENIUS Act enforcement on January 18, 2027"
+      suppressHydrationWarning
+    >
+      {units.map(([label, value], i) => (
+        <div key={label} className="flex items-stretch gap-3 sm:gap-5 md:gap-8">
+          <div className="flex flex-col items-center gap-2">
+            <span
+              className="metric-1 font-mono font-semibold tabular-nums leading-none tracking-tight text-[clamp(2.75rem,9vw,6.5rem)] drop-shadow-[0_0_32px_oklch(53.51%_0.163_39.51/0.35)]"
+              suppressHydrationWarning
+            >
+              {value}
+            </span>
+            <span className="font-mono text-[0.65rem] uppercase tracking-[0.26em] text-white/40">
+              {label}
+            </span>
+          </div>
+          {i < units.length - 1 && (
+            <span className="hidden sm:block font-mono font-light text-lit-orange-700/70 leading-none text-[clamp(2rem,7vw,5rem)] pb-7 self-start">
+              :
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stablecoins/_components/PaperLayout.tsx
+++ b/src/app/stablecoins/_components/PaperLayout.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useState } from 'react';
+import { HeaderMenu } from '@/components/Header/Header';
+import { NavMenu2 } from '@/components/NavMenu/NavMenu2';
+
+// Same chrome as the site Layout (header + slide-out nav) but without the global
+// newsletter Footer — the white paper ends with its own References and disclaimer.
+export default function PaperLayout({ children }: { children: React.ReactNode }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const toggleMenu = () => setMenuOpen((v) => !v);
+
+  return (
+    <>
+      <HeaderMenu menuOpen={menuOpen} toggleMenu={toggleMenu} />
+      <main className="relative h-full min-h-[100vh] w-full">{children}</main>
+      <NavMenu2 menuOpen={menuOpen} toggleMenu={toggleMenu} />
+    </>
+  );
+}

--- a/src/app/stablecoins/_components/WhitePaper.tsx
+++ b/src/app/stablecoins/_components/WhitePaper.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import { Container } from '@mantine/core';
+import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Button } from '@/components/ui/Button';
+import Countdown from './Countdown';
+import { SRC } from './citations';
+
+const DOCS_EXAMPLES = 'https://developer.litprotocol.com/lit-actions/examples';
+const DEPLOYMENT_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLScQ8dU09fbdRa6Al70rP9Bb-iX_CngnGl1U6_YFh7s0UyKgkQ/viewform';
+
+// Defined before the data tables below, which reference it (const is not hoisted — TDZ).
+const Fn = ({ n }: { n: number }) => (
+  <sup className="ml-px">
+    <a href={`#ref-${n}`} className="font-mono text-[0.6em] text-lit-orange transition-colors hover:text-gold-500">
+      [{n}]
+    </a>
+  </sup>
+);
+
+/* ---------------- structure ---------------- */
+
+const SECTIONS = [
+  { id: 'forcing-function', n: '1', title: 'The forcing function' },
+  { id: 'problem', n: '2', title: 'Control by promise' },
+  { id: 'shift', n: '3', title: 'Provable control' },
+  { id: 'external', n: '4', title: 'External compliance' },
+  { id: 'internal', n: '5', title: 'Internal compliance' },
+  { id: 'architecture', n: '6', title: 'The architecture' },
+  { id: 'proof', n: '7', title: 'What an issuer can prove' },
+  { id: 'implementation', n: '8', title: 'Implementation' },
+  { id: 'references', n: '9', title: 'References' },
+];
+
+const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
+  { n: 1, text: 'GENIUS Act, Pub. L. No. 119-27, 139 Stat. 419 (July 18, 2025), § 4(a)(5) (permitted payment stablecoin issuer treated as a financial institution under the Bank Secrecy Act; effective AML and economic-sanctions compliance program).', href: SRC.geniusText },
+  { n: 2, text: 'GENIUS Act § 2(16) (definition of “lawful order”); § 4(a)(5) (technological capability to comply with a lawful order to seize, freeze, burn, or prevent the transfer of stablecoins).', href: SRC.geniusText },
+  { n: 3, text: 'FinCEN & OFAC, Permitted Payment Stablecoin Issuer AML/CFT Program and Sanctions Compliance Program Requirements (Proposed Rule), 91 Fed. Reg. (Apr. 10, 2026), Doc. No. 2026-06963; public comment closes June 9, 2026.', href: SRC.npr },
+  { n: 4, text: 'GENIUS Act § 20 (effective on the earlier of 18 months after enactment or 120 days after final implementing regulations).', href: SRC.geniusPDF },
+  { n: 5, text: 'U.S. Department of the Treasury, proposed rule implementing the GENIUS Act’s illicit-finance requirements (Apr. 2026).', href: SRC.treasury },
+  { n: 6, text: 'Lit Protocol, “Introducing Lit Protocol v3 (Chipotle)” — TEE-based execution, on-chain key orchestration, and hardware attestation.', href: SRC.chipotle },
+  { n: 7, text: 'Lit Protocol developer documentation — architecture and security.', href: SRC.litDocs },
+  { n: 8, text: '“Proof of Cloud: Data Center Execution Assurance for Confidential VMs,” arXiv:2510.12469; Flashbots, “Mind the Gap.”', href: SRC.pocPaper },
+];
+
+const TABLE1: { ob: ReactNode; cap: ReactNode }[] = [
+  { ob: <>Block or reject a prohibited transfer <em className="not-italic text-white">before</em> it executes<Fn n={1} /><Fn n={3} /></>, cap: 'A policy screens the counterparty against an OFAC/sanctions oracle and withholds the signature on a hit; enforcement happens at the moment of signing.' },
+  { ob: <>Comply with a lawful order to seize, freeze, or burn<Fn n={2} /></>, cap: 'Freeze and burn paths are condition-gated and governance-bound, executing only on a verified order.' },
+  { ob: <>Enforce across every chain the asset touches<Fn n={3} /></>, cap: 'One enclave-held key signs across Bitcoin, EVM, Solana and Cosmos, and reorg-validates cross-chain mint and burn.' },
+  { ob: <>Reach secondary, smart-contract and agent activity<Fn n={3} /></>, cap: 'Authority is bound to the signing key and to scoped, revocable agent permissions — not to a single token contract.' },
+  { ob: <>Evidence the program and report blocked transactions<Fn n={3} /></>, cap: 'Policies are immutable and code-hash-verified; each decision is a cryptographically attested record.' },
+];
+
+const TABLE2: { who: string; claim: ReactNode }[] = [
+  { who: 'Regulator', claim: <>Pre-execution sanctions screening and lawful-order seize/freeze across every chain, with evidence of each blocked attempt.<Fn n={1} /><Fn n={3} /></> },
+  { who: 'Internal audit & SOC 2', claim: 'Segregation of duties, a complete tamper-evident trail, and control effectiveness demonstrated continuously — not sampled.' },
+  { who: 'Board & risk committee', claim: 'No key-person or insider single point of failure; policy changeable only by governance; custodial and operational risk materially reduced.' },
+  { who: 'Counterparties & customers', claim: 'A non-custodial guarantee that is cryptographically verifiable, rather than asserted.' },
+];
+
+const FLOW = [
+  { n: '01', t: 'Authorize against the chain', s: 'The enclave reads the on-chain permission contracts: is the caller allowed, and is this policy bound to this key?' },
+  { n: '02', t: 'Fetch the immutable policy', s: 'It loads the exact policy by content identifier — content-addressed, so the code cannot have been substituted.' },
+  { n: '03', t: 'Enforce', s: 'The policy runs in a sandbox: sanctions screen, supply cap, jurisdiction, limits. If any check fails, no signature is produced.' },
+  { n: '04', t: 'Sign, without exposing the key', s: 'Only on success does the enclave use the key. The key never leaves the hardware; the decision is attested.' },
+];
+
+/* ---------------- primitives ---------------- */
+
+const P = ({ children }: { children: ReactNode }) => (
+  <p className="mt-4 text-[1.02rem] leading-[1.72] text-white/70">{children}</p>
+);
+
+const Lead = ({ children }: { children: ReactNode }) => <strong className="font-medium text-white">{children}</strong>;
+
+function SectionHead({ n, id, title }: { n: string; id: string; title: string }) {
+  return (
+    <div className="mb-2 flex items-baseline gap-3">
+      <span className="font-mono text-sm text-lit-orange-700">{n}</span>
+      <h2 className="text-[clamp(1.5rem,2.6vw,2rem)] font-medium leading-tight tracking-tight" id={id}>
+        {title}
+      </h2>
+    </div>
+  );
+}
+
+/* ---------------- document ---------------- */
+
+export default function WhitePaper() {
+  const [active, setActive] = useState<string>('forcing-function');
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setActive((e.target as HTMLElement).id);
+        });
+      },
+      { rootMargin: '-20% 0px -70% 0px' }
+    );
+    SECTIONS.forEach((s) => {
+      const el = document.getElementById(`sec-${s.id}`);
+      if (el) obs.observe(el);
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div className="bg-coal-950 text-white">
+      {/* MASTHEAD */}
+      <header className="relative overflow-hidden border-b border-white/10">
+        <div className="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[min(1000px,140vw)] -translate-x-1/2 -translate-y-1/3 blur-[10px] bg-[radial-gradient(ellipse_at_center,_oklch(53.51%_0.163_39.51/0.20)_0%,_transparent_64%)]" />
+        <Container size="lg" className="relative !pt-20 !pb-16 md:!pt-28">
+          <div className="font-mono text-xs uppercase tracking-[0.28em] text-lit-orange">White paper</div>
+          <h1 className="mt-5 max-w-[18ch] text-[clamp(2.5rem,6.5vw,5rem)] font-medium leading-[1.0] tracking-tight">
+            Provable Compliance
+          </h1>
+          <p className="mt-5 max-w-[46ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
+            Code-enforced control for regulated stablecoins and tokenized assets.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
+            <span>Version 1.0 · June 2026</span>
+            <span className="text-white/15">|</span>
+            <span className="text-white/60">
+              GENIUS Act takes effect in <Countdown compact /> — January 18, 2027
+            </span>
+          </div>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+              Book a deployment review
+            </Button>
+            <Button variant="outline" href={DOCS_EXAMPLES} target="_blank" rel="noopener noreferrer">
+              See the Lit Actions examples
+            </Button>
+          </div>
+        </Container>
+      </header>
+
+      <Container size="lg" className="!py-16 md:!py-20">
+        {/* ABSTRACT */}
+        <div className="mx-auto max-w-[44rem] rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
+          <div className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-lit-orange">Abstract</div>
+          <p className="text-[1.05rem] leading-[1.75] text-white/80">
+            On January 18, 2027, the GENIUS Act makes every permitted U.S. payment-stablecoin issuer a financial institution that must demonstrate the technical capability to block, freeze, and seize transfers — before they execute, across every chain, and prove it to an examiner.<Fn n={1} /><Fn n={3} /> An issuer that meets this bar with a privileged administrative key and a written procedure satisfies neither the regulator nor its own internal controls: both rest on trust in people and processes, and both detect failure only after it has settled. This paper sets out a different control architecture. When an asset’s signing authority is generated and used only inside sealed hardware, and governed by code whose permissions are recorded on-chain, the control cannot be circumvented by an operator, an intruder, or an error — and every action it takes leaves a verifiable record. Compliance becomes something an issuer can <Lead>prove</Lead> rather than promise: to its regulator, its auditor, its board, and its counterparties.
+          </p>
+        </div>
+
+        {/* GRID: TOC + body */}
+        <div className="wp-grid mt-16 lg:grid lg:grid-cols-[200px_minmax(0,44rem)] lg:justify-center lg:gap-16">
+          {/* TOC */}
+          <nav className="mb-10 hidden lg:block">
+            <div className="sticky top-24">
+              <div className="mb-4 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-white/40">Contents</div>
+              <ul className="space-y-2.5">
+                {SECTIONS.map((s) => (
+                  <li key={s.id}>
+                    <a
+                      href={`#sec-${s.id}`}
+                      className={`flex gap-2.5 text-sm transition-colors ${active === s.id ? 'text-lit-orange' : 'text-white/45 hover:text-white/80'}`}
+                    >
+                      <span className="font-mono text-xs opacity-60">{s.n}</span>
+                      {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </nav>
+
+          {/* BODY */}
+          <article className="wp-doc max-w-[44rem]">
+            {/* 1 */}
+            <section id="sec-forcing-function" className="scroll-mt-24">
+              <SectionHead n="1" id="forcing-function" title="The forcing function" />
+              <P>
+                The GENIUS Act (Public Law 119-27) brings U.S. payment stablecoins inside the federal perimeter. A permitted issuer is treated as a financial institution under the Bank Secrecy Act and must maintain an effective anti-money-laundering and economic-sanctions compliance program.<Fn n={1} /> It must also hold the technological capability to comply with a lawful order to “seize, freeze, burn, or prevent the transfer” of the stablecoins it issues.<Fn n={2} />
+              </P>
+              <P>
+                The rule proposed by FinCEN and OFAC in April 2026 makes the engineering requirement explicit: issuers need the “policies, procedures, and the technical capability to block, freeze, and reject” specific transactions, and the agencies stress preventing a prohibited transfer rather than unwinding it afterward.<Fn n={3} /> Public comment closes June 9, 2026; the Act takes effect on the earlier of eighteen months after enactment or 120 days after final rules — January 18, 2027.<Fn n={4} />
+              </P>
+              <P>This is the deadline. The capability it requires also serves the issuer’s own internal controls, as the following sections set out.</P>
+            </section>
+
+            {/* 2 */}
+            <section id="sec-problem" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="2" id="problem" title="Control by promise" />
+              <P>
+                Most issuers will meet a control obligation the way the industry always has: a privileged key on the token contract, held by a custodian or an internal team, plus a written policy describing how that key will be used. The regulator — and the issuer’s own control framework — are then asked to trust three things: that the key is held securely, that it is used only as the policy says, and that misuse would be detected. Each is verified after the fact, by sampling logs.
+              </P>
+              <P>This model is <Lead>promissory and post-hoc</Lead>, and it is weak by the standard of any serious control framework:</P>
+              <ul className="mt-4 space-y-3">
+                {[
+                  ['It acts too late.', 'A freeze unwinds a transfer that has already settled; the rule asks issuers to prevent it.'],
+                  ['It does not travel.', 'A control on one chain does not reach the same asset bridged to another.'],
+                  ['It does not reach far enough.', 'A contract-level blacklist cannot stop a smart contract, a self-custodied wallet, or an autonomous agent from initiating a non-compliant transfer.'],
+                  ['It depends on a person.', 'A key one administrator can use is a key one administrator can misuse, be compelled to use, or use by mistake — and a single point of compromise.'],
+                ].map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange-700" />
+                    <Lead>{h}</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>
+                The regulator and the internal auditor share the same concern. A control that a single party can circumvent, that produces no tamper-evident record, and whose effectiveness can only be sampled is weak under COSO, SOC 2, and SOX alike.
+              </P>
+            </section>
+
+            {/* 3 */}
+            <section id="sec-shift" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="3" id="shift" title="Provable control" />
+              <P>The alternative is to verify the system rather than trust the operator. Three properties make that possible:</P>
+              <ul className="mt-4 space-y-3">
+                {[
+                  ['Blind.', 'The signing key is generated and used only inside a sealed trusted execution environment (TEE). No operator, host, or vendor — Lit included — can see or extract it.'],
+                  ['Bound.', 'The key’s authority is not an administrative setting but on-chain state: it signs only what an immutable, content-addressed policy permits.'],
+                  ['Provable.', 'Every decision the key makes, and every transfer it refuses, is an attested record that anyone entitled to it can verify.'],
+                ].map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/80">
+                    <span className="absolute left-0 top-[0.55rem] font-mono text-lit-orange">◆</span>
+                    <Lead>{h}</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>
+                Together they close the gap between policy and enforcement: the key leaves human hands, and no privileged actor can sign around the control. That is what <Lead>impossible to misuse</Lead> means here; §6 makes it precise. These are also the properties an internal control framework requires, which §5 takes up.
+              </P>
+            </section>
+
+            {/* 4 */}
+            <section id="sec-external" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="4" id="external" title="External compliance" />
+              <P>Each obligation the GENIUS Act and the proposed rule impose maps to a capability enforced at the moment of signing, rather than asserted in a policy.</P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-2/5 p-4 font-normal">Obligation</th>
+                      <th className="p-4 font-normal">Enforced capability</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TABLE1.map((r, i) => (
+                      <tr key={i} className="border-t border-white/10 align-top">
+                        <td className="p-4 text-[0.95rem] font-medium text-white">{r.ob}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.cap}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Table 1 — Statutory and regulatory obligations mapped to capabilities enforced at signing.</figcaption>
+            </section>
+
+            {/* 5 */}
+            <section id="sec-internal" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="5" id="internal" title="Internal compliance" />
+              <P>The same architecture answers the questions an internal audit, a SOC 2 assessor, and a board risk committee ask — often more cleanly than a conventional stack.</P>
+              <ul className="mt-4 space-y-4">
+                {[
+                  ['Segregation of duties, enforced cryptographically.', 'No single person can mint, move, or freeze; authority is split across the network and bound to policy. Segregation of duties stops being an administrative arrangement that can be quietly undone and becomes a property of the system.'],
+                  ['A complete, tamper-evident audit trail.', 'Every action — and every blocked attempt — is an attested, immutable record. An issuer can evidence that a control operated, continuously, not merely that it was designed; that distinction is what external auditors actually test.'],
+                  ['Change management by construction.', 'The policy is code: versioned, content-addressed, and alterable only through on-chain governance. There is no out-of-band configuration change to reconcile.'],
+                  ['A smaller risk surface.', 'There is no custodial key to steal, subpoena, or fat-finger; the insider, coercion, and operational-error paths are removed rather than monitored. The October 2025 episode in which an issuer accidentally minted and then unwound trillions of dollars is precisely the class of error a supply-cap invariant in code prevents.'],
+                  ['Continuous assurance.', 'The control operates and is evidenced in real time, not attested once a quarter.'],
+                ].map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange" />
+                    <Lead>{h}</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>None of this is a separate product. It is the same enforcement described in §4 and §6, assessed against internal-control standards rather than the statute.</P>
+            </section>
+
+            {/* 6 */}
+            <section id="sec-architecture" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="6" id="architecture" title="The architecture" />
+              <P>Three layers implement the three properties. Each is independently inspectable.</P>
+              <P>
+                <Lead>Blind execution.</Lead> Lit Actions — the policies — run inside trusted execution environments, where the signing key is derived and used. The network connection terminates inside the enclave, so there is no point at which key material is exposed; nothing that touches it leaves.<Fn n={6} /><Fn n={7} />
+              </P>
+              <P>
+                <Lead>Bound to the chain.</Lead> A key’s authority is on-chain state on Base: permission contracts bind each key to the exact, content-addressed policies it may run. Changing what a key can do means changing on-chain state under the issuer’s own governance — not flipping an administrative switch.<Fn n={6} />
+              </P>
+              <P>
+                <Lead>Provable hardware.</Lead> Each enclave emits a hardware attestation: a signed, deterministic measurement of the exact code running inside. The Proof of Cloud approach extends that attestation to prove the machine runs in vetted infrastructure rather than on an attacker’s bench — binding the chip’s identity to a second root of trust and closing the physical side-channel gap.<Fn n={8} />
+              </P>
+              <figure className="mt-7 rounded-2xl border border-dashed border-lit-orange/30 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.06),_transparent_60%)] px-5 pb-6 pt-9">
+                <span className="-mt-12 mb-1 block font-mono text-[0.7rem] tracking-wide text-lit-orange">Sealed enclave · operators are blind</span>
+                <div className="mt-3 grid gap-2.5">
+                  {FLOW.map((f) => (
+                    <div key={f.n} className="flex items-start gap-4 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span className="w-6 shrink-0 pt-0.5 font-mono text-xs font-semibold text-lit-orange">{f.n}</span>
+                      <div>
+                        <b className="block text-[0.95rem] font-medium">{f.t}</b>
+                        <span className="text-sm text-white/55">{f.s}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Figure 1 — The lifecycle of a single signing request inside the enclave.</figcaption>
+              <P>
+                <Lead>A note on trust.</Lead> No system eliminates trust; it relocates trust to assumptions that can be independently verified. Here those assumptions are the silicon vendor’s hardware root of trust and the on-chain governance that sets policy — both externally attestable, the former hardened by Proof of Cloud. There is no trusted operator.
+              </P>
+            </section>
+
+            {/* 7 */}
+            <section id="sec-proof" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="7" id="proof" title="What an issuer can prove" />
+              <P>The result is one architecture whose guarantees can be demonstrated to four different audiences.</P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-1/4 p-4 font-normal">Audience</th>
+                      <th className="p-4 font-normal">What an issuer can prove</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TABLE2.map((r, i) => (
+                      <tr key={i} className="border-t border-white/10 align-top">
+                        <td className="whitespace-nowrap p-4 text-[0.95rem] font-medium text-white">{r.who}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.claim}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Table 2 — Guarantees demonstrable to each audience.</figcaption>
+            </section>
+
+            {/* 8 */}
+            <section id="sec-implementation" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="8" id="implementation" title="Implementation" />
+              <P>
+                Demonstrable capability is reached fastest by starting narrow. A reference implementation can enforce sanctions-screened, supply-capped minting on a single asset and a single chain, prove it end-to-end against the proposed rule’s requirements, and expand from there. The goal before January 18, 2027 is a control an examiner and an auditor can verify — not a finished platform.
+              </P>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+                  Book a deployment review
+                </Button>
+                <Button variant="outline" href={DOCS_EXAMPLES} target="_blank" rel="noopener noreferrer">
+                  See the Lit Actions examples
+                </Button>
+              </div>
+            </section>
+
+            {/* 9 */}
+            <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="9" id="references" title="References" />
+              <ol className="mt-4 space-y-3">
+                {REFERENCES.map((r) => (
+                  <li key={r.n} id={`ref-${r.n}`} className="scroll-mt-24 flex gap-3 text-[0.9rem] leading-relaxed text-white/60">
+                    <span className="font-mono text-xs text-lit-orange-700">[{r.n}]</span>
+                    <span>
+                      {r.text}{' '}
+                      <a href={r.href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 whitespace-nowrap text-lit-orange transition-colors hover:text-gold-500">
+                        link <IconExternalLink size={11} stroke={2} className="opacity-70" />
+                      </a>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              <p className="mt-10 border-t border-white/10 pt-5 font-mono text-[0.7rem] leading-relaxed text-white/30">
+                Informational only — not legal advice. Summarizes the GENIUS Act of 2025 (Pub. L. No. 119-27) and the FinCEN/OFAC proposed rule (91 Fed. Reg., Apr. 10, 2026; Doc. 2026-06963), which is not final and may change; comments close June 9, 2026. Architecture described is current to Lit Protocol v3 and subject to change. Consult qualified counsel before relying on any statement here.
+              </p>
+            </section>
+          </article>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/app/stablecoins/_components/citations.ts
+++ b/src/app/stablecoins/_components/citations.ts
@@ -1,0 +1,21 @@
+// Authoritative source links for the /stablecoins pages. Keep citations exact.
+
+export const SRC = {
+  // GENIUS Act — Pub. L. No. 119-27, 139 Stat. 419 (July 18, 2025)
+  geniusText: 'https://www.congress.gov/bill/119th-congress/senate-bill/1582/text',
+  geniusPDF: 'https://www.congress.gov/119/plaws/publ27/PLAW-119publ27.pdf',
+  // FinCEN/OFAC Proposed Rule — 91 Fed. Reg. (Apr. 10, 2026), Doc. 2026-06963
+  npr: 'https://www.federalregister.gov/documents/2026/04/10/2026-06963/permitted-payment-stablecoin-issuer-anti-money-launderingcountering-the-financing-of-terrorism',
+  treasury: 'https://home.treasury.gov/news/press-releases/sb0435',
+  fincen:
+    'https://www.fincen.gov/resources/statutes-regulations/federal-register-notices/permitted-payment-stablecoin-issuer-anti',
+  // Lit architecture
+  chipotle: 'https://spark.litprotocol.com/introducing-lit-protocol-v3-chipotle/',
+  litDocs: 'https://developer.litprotocol.com',
+  // Proof of Cloud
+  pocSite: 'https://proofofcloud.org/',
+  pocPaper: 'https://arxiv.org/abs/2510.12469',
+  pocFlashbots: 'https://writings.flashbots.net/mind-the-gap-tee-poc',
+};
+
+export type SourceItem = { label: string; note?: string; href: string };

--- a/src/app/stablecoins/how-it-works/page.tsx
+++ b/src/app/stablecoins/how-it-works/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+// The trust model is now folded into the white paper (§6, The architecture).
+export default function HowItWorksRedirect() {
+  redirect('/stablecoins#sec-architecture');
+}

--- a/src/app/stablecoins/opengraph-image.tsx
+++ b/src/app/stablecoins/opengraph-image.tsx
@@ -1,0 +1,120 @@
+import { ImageResponse } from 'next/server';
+
+export const runtime = 'edge';
+export const alt =
+  'Provable Compliance — a Lit Protocol white paper on code-enforced control for regulated stablecoins and tokenized assets.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Bespoke Open Graph / Twitter card for /stablecoins (Next wires it automatically).
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '84px',
+          background: '#0b0806',
+          color: 'white',
+          position: 'relative',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: -180,
+            right: -160,
+            width: 680,
+            height: 680,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,91,41,0.22) 0%, transparent 62%)',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: -220,
+            left: -180,
+            width: 620,
+            height: 620,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,206,94,0.12) 0%, transparent 62%)',
+          }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: 24,
+            letterSpacing: '0.28em',
+            color: '#ff8a3d',
+            marginBottom: 30,
+            fontFamily: 'monospace',
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 999,
+              background: '#ff5b29',
+              display: 'flex',
+            }}
+          />
+          LIT PROTOCOL · WHITE PAPER
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 108,
+            fontWeight: 600,
+            letterSpacing: '-0.03em',
+            lineHeight: 1,
+          }}
+        >
+          Provable Compliance
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 34,
+            color: 'rgba(246,237,226,0.72)',
+            marginTop: 28,
+            maxWidth: 880,
+            lineHeight: 1.3,
+          }}
+        >
+          Code-enforced control for regulated stablecoins and tokenized assets.
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginTop: 60,
+            color: 'rgba(255,255,255,0.5)',
+            fontSize: 24,
+            fontFamily: 'monospace',
+            letterSpacing: '0.12em',
+          }}
+        >
+          <span style={{ display: 'flex' }}>litprotocol.com/stablecoins</span>
+          <span style={{ display: 'flex' }}>GENIUS ACT · JAN 18 2027</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/stablecoins/page.tsx
+++ b/src/app/stablecoins/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import PaperLayout from './_components/PaperLayout';
+import WhitePaper from './_components/WhitePaper';
+
+const URL = 'https://litprotocol.com/stablecoins';
+const DESCRIPTION =
+  'The GENIUS Act takes effect Jan 18, 2027. How stablecoin and tokenized-asset issuers enforce block, freeze, and seize controls in code — and prove it.';
+
+export const metadata: Metadata = {
+  title: 'Provable Compliance: Stablecoins & the GENIUS Act | Lit Protocol',
+  description: DESCRIPTION,
+  alternates: { canonical: '/stablecoins' },
+  openGraph: {
+    type: 'article',
+    title: 'Provable Compliance — Code-Enforced Control for Regulated Assets',
+    description: DESCRIPTION,
+    url: URL,
+    siteName: 'Lit Protocol',
+    publishedTime: '2026-06-01T00:00:00.000Z',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Provable Compliance — Lit Protocol',
+    description: DESCRIPTION,
+    creator: '@LitProtocol',
+  },
+  robots: { index: true, follow: true },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Provable Compliance',
+  alternativeHeadline:
+    'Code-enforced control for regulated stablecoins and tokenized assets',
+  description: DESCRIPTION,
+  inLanguage: 'en',
+  datePublished: '2026-06-01',
+  dateModified: '2026-06-01',
+  author: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    url: 'https://litprotocol.com',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://litprotocol.com/lit-logo.png',
+    },
+  },
+  mainEntityOfPage: URL,
+  image: 'https://litprotocol.com/api/og',
+  about: [
+    'GENIUS Act',
+    'stablecoin compliance',
+    'tokenized assets',
+    'sanctions screening',
+  ],
+};
+
+export default function StablecoinsPage() {
+  return (
+    <PaperLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <WhitePaper />
+    </PaperLayout>
+  );
+}


### PR DESCRIPTION
## What

Adds **`/stablecoins`** — a "Provable Compliance" position paper for stablecoin & tokenized-asset issuers, framed on the **GENIUS Act** (effective Jan 18, 2027) and how Lit's code-enforced, on-chain-governed key control satisfies **both external regulatory and internal-compliance** requirements. The trust model (TEE / on-chain permissions / Proof of Cloud) is folded in as §6.

Ships at **`litprotocol.com/stablecoins`**.

## Scope — additive, no existing files changed

New route under `src/app/stablecoins/`:
- `page.tsx` — route, SEO metadata, `TechArticle` JSON-LD
- `how-it-works/page.tsx` — redirect → `/stablecoins#sec-architecture`
- `_components/` — `WhitePaper`, `PaperLayout` (site header + slide-out nav, **without** the global newsletter footer), `Countdown`, `citations`
- `opengraph-image.tsx` — bespoke OG / Twitter card

Site-wide SEO files (none existed before):
- `src/app/sitemap.ts`, `src/app/robots.ts`

## Notes

- `next build` passes green; `/stablecoins` renders **static**, OG image is an edge route, `sitemap.xml` + `robots.txt` generate.
- Uses the site's own Mantine + Tailwind tokens (Favorit, `coal-950`, `lit-orange`) — inherits the real header/nav.
- Every legal claim is footnoted to the GENIUS Act (Pub. L. 119-27, §§ 2(16), 3, 4(a)(1)/(3)/(5), 20) and the FinCEN/OFAC proposed rule (Doc. 2026-06963).

## Open items (non-blocking)

- [ ] Legal to bless the statutory citations before public launch
- [ ] Confirm "Proof of Cloud" wording (currently framed as *an approach* — ship vs. roadmap)
- [ ] Resolve the intake form's duplicate email field (Google Forms auto-email + manual "Work Email")
- [ ] Optional: drop the "White paper" eyebrow if the title should stand alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
