### PR TITLE
feat: add cross-chain solvers report page

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: `${BASE}/`, lastModified, changeFrequency: 'weekly', priority: 1 },
     { url: `${BASE}/stablecoins`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
+    { url: `${BASE}/solvers`, lastModified, changeFrequency: 'monthly', priority: 0.9 },
     { url: `${BASE}/careers`, lastModified, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${BASE}/legal/privacy-policy`, lastModified, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE}/legal/terms-of-service`, lastModified, changeFrequency: 'yearly', priority: 0.3 },

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -216,12 +216,12 @@ export default function SolversReport() {
       <header className="relative overflow-hidden border-b border-white/10">
         <div className="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[min(1000px,140vw)] -translate-x-1/2 -translate-y-1/3 blur-[10px] bg-[radial-gradient(ellipse_at_center,_oklch(53.51%_0.163_39.51/0.22)_0%,_transparent_64%)]" />
         <Container size="lg" className="relative !pt-20 !pb-16 md:!pt-28">
-          <div className="font-mono text-xs uppercase tracking-[0.28em] text-lit-orange">Industry report</div>
+          <div className="font-mono text-xs uppercase tracking-[0.28em] text-lit-orange">Position paper</div>
           <h1 className="mt-5 max-w-[18ch] text-[clamp(2.5rem,6.5vw,5rem)] font-medium leading-[1.0] tracking-tight">
             Cross-Chain Solvers
           </h1>
           <p className="mt-5 max-w-[48ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
-            A state-of-the-market report on fillers, RFQ makers, intent routers, and settlement rails.
+            A state-of-the-market survey of fillers, RFQ makers, intent routers, and settlement rails.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
             <span>Version 0.1 · June 2026</span>

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { Container } from '@mantine/core';
-import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
+import { IconExternalLink } from '@tabler/icons-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/Button';
 
-const DEPLOYMENT_FORM =
-  'https://docs.google.com/forms/d/e/1FAIpQLScQ8dU09fbdRa6Al70rP9Bb-iX_CngnGl1U6_YFh7s0UyKgkQ/viewform';
 const SOLVER_VAULT_EXAMPLE =
   'https://github.com/LIT-Protocol/chipotle/tree/main/examples/lit-solver-vault';
 
@@ -19,14 +17,15 @@ const Fn = ({ n }: { n: number }) => (
 );
 
 const SECTIONS = [
-  { id: 'market', n: '1', title: 'The market' },
-  { id: 'taxonomy', n: '2', title: 'Solver taxonomy' },
-  { id: 'techniques', n: '3', title: 'Execution patterns' },
-  { id: 'risks', n: '4', title: 'Control surfaces' },
-  { id: 'lit', n: '5', title: 'Where Lit fits' },
-  { id: 'map', n: '6', title: 'Company map' },
-  { id: 'outreach', n: '7', title: 'Outreach workflow' },
-  { id: 'references', n: '8', title: 'References' },
+  { id: 'forcing-function', n: '1', title: 'The forcing function' },
+  { id: 'solver-role', n: '2', title: 'The solver role' },
+  { id: 'execution-models', n: '3', title: 'Execution models' },
+  { id: 'ecosystem', n: '4', title: 'The ecosystem' },
+  { id: 'fault-lines', n: '5', title: 'Operational fault lines' },
+  { id: 'verifiable-control', n: '6', title: 'Verifiable control' },
+  { id: 'proof', n: '7', title: 'What a solver can prove' },
+  { id: 'open-questions', n: '8', title: 'Open questions' },
+  { id: 'references', n: '9', title: 'References' },
 ];
 
 const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
@@ -94,31 +93,46 @@ const CONTROL_SURFACES = [
   ['Inventory custody', 'Funds often sit in EOAs, smart accounts, vault contracts, protocol balances, or venue accounts. The critical question is not only where funds sit, but what runtime conditions are required before they can move.'],
   ['Order reconstruction', 'Before a fill, claim, or rebalance, a solver must reconstruct source-chain events, bridge attestations, quote IDs, deadlines, recipients, token amounts, and replay constraints.'],
   ['Latency budget', 'A 100 ms quote path cannot carry the same checks as a settlement, withdrawal, or rebalance path. Controls have to be placed at the right phase of the lifecycle.'],
-  ['Onboarding model', '“Solver” can mean permissionless filler, allowlisted resolver, private RFQ maker, bonded relayer, internal executor, or infrastructure node. Each carries different trust and sales motion.'],
+  ['Participation model', '“Solver” can mean permissionless filler, allowlisted resolver, private RFQ maker, bonded relayer, internal executor, or infrastructure node. Each carries different trust and operational assumptions.'],
   ['Standards compatibility', 'ERC-7683 is creating a shared cross-chain intent language, but production systems still use many protocol-specific order formats and API payloads.'],
 ];
 
-const LIT_FITS = [
-  ['Policy-gated inventory', 'Put solver inventory behind a vault or signing flow that releases funds only when a Lit Action verifies the order, route, amount, deadline, profitability, and risk limits.'],
-  ['Attested execution', 'Run authorization logic inside TEEs and produce evidence that the exact policy approved or denied a fill, claim, withdrawal, or rebalance.'],
-  ['Cross-chain source verification', 'Use Lit Actions to read source-chain state, bridge attestations, VAAs, CCTP messages, or settlement roots before signing a downstream action.'],
-  ['Role separation', 'Separate quote generation, strategy, execution, withdrawal, and emergency permissions so no single bot or operator has unilateral inventory authority.'],
-  ['Company-specific deployment', 'The right wedge differs by category: Across-style relayer fills, RFQ quote signing, CCTP rebalancing, and aggregator executor wallets need different policies.'],
+const VERIFIABLE_CONTROLS = [
+  ['Policy-gated inventory', 'Solver inventory can sit behind a vault or signing flow that releases funds only when code verifies the order, route, amount, deadline, profitability, and risk limits.'],
+  ['Attested execution', 'Authorization logic can run inside TEEs and produce evidence that a specific policy approved or denied a fill, claim, withdrawal, or rebalance.'],
+  ['Cross-chain source verification', 'Source-chain state, bridge attestations, VAAs, CCTP messages, or settlement roots can be checked before a downstream action is signed.'],
+  ['Role separation', 'Quote generation, strategy, execution, withdrawal, and emergency permissions can be separated so no single bot or operator has unilateral inventory authority.'],
+  ['Phase-aware controls', 'The controls used for quoting, filling, claiming, and rebalancing can differ according to each phase’s latency budget and risk profile.'],
 ];
 
-const COMPANY_MAP = [
-  ['P0', 'Across', 'Fast-fill relayer network', 'Relayer inventory custody, exclusive flows, fill authorization latency.'],
-  ['P0', 'deBridge DLN', '0-TVL cross-chain order network', 'Taker/filler claim keys, order fulfillment flow, reserve custody.'],
-  ['P0', 'Wormhole Settlement / Mayan', 'Settlement and solver ecosystem', 'Solver curation, VAA/CCTP verification, fast auction constraints.'],
-  ['P0', '1inch Fusion+', 'Cross-chain Dutch-auction resolver network', 'Resolver keys, escrow flow, secret generation and reveal.'],
-  ['P0', 'Squid Coral', 'Intent swaps over Axelar', 'Solver participation model, quote signing, inventory risk.'],
-  ['P0', 'Relay.link', 'Managed fast bridging and execution API', 'Liquidity provider custody, signer modes, rebalancing paths.'],
-  ['P1', 'UniswapX', 'Dutch-auction filler system', 'Cross-chain filler inventory, RFQ paths, reactor settlement.'],
-  ['P1', 'CoW Protocol', 'Batch-auction solver network', 'Settlement signing, solver buffers, hooks, simulation.'],
-  ['P1', 'LI.FI', 'Aggregator and intent router', 'Executor roles, solver access, route-safety policies.'],
-  ['P1', 'Socket / Bungee', 'Chain-abstraction orchestration', 'Transmitters, EIP-7683 support, gas and refund control.'],
-  ['P1', 'Hashflow / Bebop', 'RFQ market-maker networks', 'Quote-signing keys, stale quotes, PMM inventory controls.'],
-  ['P2', 'Everclear', 'Clearing and netting layer', 'Solver rebalancing reduction, settlement responsibilities.'],
+const PROOF_POINTS = [
+  ['Inventory moved under policy', 'A fill, claim, withdrawal, or rebalance was authorized only after the required order, route, limit, and risk checks passed.'],
+  ['A denial was real', 'A risky or invalid request failed because the policy refused to sign, not because an operator happened to notice it.'],
+  ['The signer was constrained', 'The key could not be exported or used outside the allowed policy path, reducing hot-wallet and insider risk.'],
+  ['The execution path is auditable', 'The decision can be tied to code identity, chain state, and the specific cross-chain facts that were observed at signing time.'],
+];
+
+const ECOSYSTEM = [
+  ['Across', 'Fast-fill relayer network', 'Relayers fill users on the destination chain and are repaid through optimistic settlement bundles.'],
+  ['deBridge DLN', '0-TVL cross-chain order network', 'Takers fulfill destination orders and later claim or unlock source-side value.'],
+  ['Wormhole Settlement / Mayan', 'Settlement and solver ecosystem', 'Solvers compete around Wormhole attestations, CCTP, and fast auction flows.'],
+  ['1inch Fusion+', 'Cross-chain Dutch-auction resolver network', 'Resolvers coordinate source and destination escrows using hashlock and timelock-style mechanics.'],
+  ['Squid Coral', 'Intent swaps over Axelar', 'Solvers quote and fill intent swaps while Axelar provides cross-chain transport.'],
+  ['Relay.link', 'Managed fast bridging and execution API', 'Relay and liquidity providers deliver fast destination execution and rebalance behind the API.'],
+  ['UniswapX', 'Dutch-auction filler system', 'Fillers compete to execute signed orders through reactor contracts; cross-chain variants extend the model.'],
+  ['CoW Protocol', 'Batch-auction solver network', 'Solvers compete to produce aggregate settlements across user intents and liquidity venues.'],
+  ['LI.FI', 'Aggregator and intent router', 'Routes across bridges, DEX aggregators, intent protocols, and status/execution APIs.'],
+  ['Socket / Bungee', 'Chain-abstraction orchestration', 'Coordinates route execution, transmitters, and EIP-7683-compatible order surfaces.'],
+  ['Hashflow / Bebop', 'RFQ market-maker networks', 'Professional makers quote firm prices against private inventory across supported chains.'],
+  ['Everclear', 'Clearing and netting layer', 'Nets cross-chain obligations to reduce solver rebalancing cost and settlement friction.'],
+];
+
+const OPEN_QUESTIONS = [
+  'Which solver roles are actually permissionless today, and which remain allowlisted or relationship-driven?',
+  'How much policy checking can happen before quote, before fill, before claim, and before rebalance without breaking latency?',
+  'Will ERC-7683 become the common order format, or will production systems continue to use protocol-specific payloads?',
+  'Where should risk live: in solver bots, vault contracts, TEEs, multisigs, optimistic dispute systems, or clearing layers?',
+  'How should users and applications evaluate solver reliability when fills are fast but settlement and rebalancing happen later?',
 ];
 
 const P = ({ children }: { children: ReactNode }) => (
@@ -139,7 +153,7 @@ function SectionHead({ n, id, title }: { n: string; id: string; title: string })
 }
 
 export default function SolversReport() {
-  const [active, setActive] = useState<string>('market');
+  const [active, setActive] = useState<string>('forcing-function');
 
   useEffect(() => {
     const obs = new IntersectionObserver(
@@ -167,7 +181,7 @@ export default function SolversReport() {
             Cross-Chain Solvers
           </h1>
           <p className="mt-5 max-w-[48ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
-            Market map, taxonomy, and control architecture for intent-based execution.
+            A state-of-the-market report on fillers, RFQ makers, intent routers, and settlement rails.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
             <span>Version 0.1 · June 2026</span>
@@ -175,11 +189,11 @@ export default function SolversReport() {
             <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
           </div>
           <div className="mt-9 flex flex-wrap gap-3">
-            <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
-              Discuss solver infrastructure
+            <Button href="#sec-solver-role">
+              Read the taxonomy
             </Button>
-            <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
-              See the solver vault example
+            <Button variant="outline" href="#sec-references">
+              Read the references
             </Button>
           </div>
         </Container>
@@ -214,8 +228,8 @@ export default function SolversReport() {
           </nav>
 
           <article className="wp-doc max-w-[44rem]">
-            <section id="sec-market" className="scroll-mt-24">
-              <SectionHead n="1" id="market" title="The market" />
+            <section id="sec-forcing-function" className="scroll-mt-24">
+              <SectionHead n="1" id="forcing-function" title="The forcing function" />
               <P>
                 The cross-chain user experience is moving from “choose a bridge, choose a DEX, wait, then complete the trade” to <Lead>state the outcome and let a solver compete to deliver it</Lead>. The user signs an intent or creates an order; the solver decides whether the route is profitable and safe; the protocol enforces settlement.
               </P>
@@ -224,8 +238,8 @@ export default function SolversReport() {
               </P>
             </section>
 
-            <section id="sec-taxonomy" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="2" id="taxonomy" title="Solver taxonomy" />
+            <section id="sec-solver-role" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="2" id="solver-role" title="The solver role" />
               <P>The same word, “solver,” covers several different business and technical roles. A useful taxonomy starts with how the actor gets selected and how it is repaid.</P>
               <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
                 <table className="w-full border-collapse text-left align-top">
@@ -252,8 +266,8 @@ export default function SolversReport() {
               </figure>
             </section>
 
-            <section id="sec-techniques" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="3" id="techniques" title="Execution patterns" />
+            <section id="sec-execution-models" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="3" id="execution-models" title="Execution models" />
               <P>
                 Across Dutch auctions, RFQ, batch auctions, and fast-fill networks, the operational lifecycle repeats: take an order, select a solver, execute on the destination, claim on the source, then rebalance for the next trade.
               </P>
@@ -276,9 +290,36 @@ export default function SolversReport() {
               </P>
             </section>
 
-            <section id="sec-risks" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="4" id="risks" title="Control surfaces" />
-              <P>The industry report is not only a map of protocols. It is a map of operational control surfaces that appear again and again across solver designs.</P>
+            <section id="sec-ecosystem" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="4" id="ecosystem" title="The ecosystem" />
+              <P>
+                The solver ecosystem is not a single market. It is a stack of relayers, resolvers, RFQ makers, routers, settlement systems, canonical transfer rails, and clearing layers. Some teams operate inventory directly; others coordinate execution or reduce settlement friction.
+              </P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="p-4 font-normal">Project</th>
+                      <th className="p-4 font-normal">Category</th>
+                      <th className="p-4 font-normal">Role in the solver stack</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ECOSYSTEM.map(([project, category, role]) => (
+                      <tr key={project} className="border-t border-white/10 align-top">
+                        <td className="p-4 text-[0.95rem] font-medium text-white">{project}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{category}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{role}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+            </section>
+
+            <section id="sec-fault-lines" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="5" id="fault-lines" title="Operational fault lines" />
+              <P>The state of solvers is defined as much by operational constraints as by protocol design. The same fault lines appear across otherwise different systems.</P>
               <ul className="mt-4 space-y-4">
                 {CONTROL_SURFACES.map(([h, b]) => (
                   <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
@@ -289,13 +330,13 @@ export default function SolversReport() {
               </ul>
             </section>
 
-            <section id="sec-lit" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="5" id="lit" title="Where Lit fits" />
+            <section id="sec-verifiable-control" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="6" id="verifiable-control" title="Verifiable control" />
               <P>
-                Lit is not a bridge, DEX, or router. The wedge is narrower and more fundamental: <Lead>programmable, attestable signing for solver inventory and execution authority</Lead>. A solver can keep its strategy fast while moving sensitive actions behind code-enforced policy.
+                The control problem is not unique to any one protocol. A solver needs a way to move quickly without turning every hot wallet, executor, or quote signer into an unconstrained source of loss. The emerging answer is <Lead>programmable, attestable signing for solver inventory and execution authority</Lead>: sensitive actions can move behind code-enforced policy while strategy remains fast.
               </P>
               <ul className="mt-4 space-y-4">
-                {LIT_FITS.map(([h, b]) => (
+                {VERIFIABLE_CONTROLS.map(([h, b]) => (
                   <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
                     <span className="absolute left-0 top-[0.55rem] font-mono text-lit-orange">◆</span>
                     <Lead>{h}.</Lead> {b}
@@ -303,40 +344,28 @@ export default function SolversReport() {
                 ))}
               </ul>
               <P>
-                The Chipotle repository already contains a solver vault example that demonstrates this shape: a vault releases inventory only when a Lit Action verifies the policy and authorizes the solver action.<Fn n={10} /><Fn n={11} />
+                One implementation pattern is to pair policy-gated signing with verifiable execution environments: the policy checks cross-chain facts, and the signing path produces evidence about the code and context that authorized the action. Lit’s solver vault example is included in the references as one concrete version of this architecture.<Fn n={10} /><Fn n={11} />
               </P>
-              <div className="mt-7 flex flex-wrap gap-3">
-                <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
-                  Talk through a solver design
-                </Button>
-                <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
-                  View example code
-                </Button>
-              </div>
             </section>
 
-            <section id="sec-map" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="6" id="map" title="Company map" />
+            <section id="sec-proof" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="7" id="proof" title="What a solver can prove" />
               <P>
-                The first outreach list should focus on companies whose products already expose solver, filler, RFQ, or route-executor control surfaces. Each profile should verify the architecture before moving into a sales conversation.
+                A mature solver stack should be able to show more than a transaction hash after the fact. It should be able to show why an action was allowed, why a risky action was denied, and which code path held authority over inventory.
               </P>
               <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
                 <table className="w-full border-collapse text-left align-top">
                   <thead>
                     <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
-                      <th className="w-16 p-4 font-normal">Priority</th>
-                      <th className="p-4 font-normal">Company / project</th>
-                      <th className="p-4 font-normal">Category</th>
-                      <th className="p-4 font-normal">Verify first</th>
+                      <th className="w-1/3 p-4 font-normal">Claim</th>
+                      <th className="p-4 font-normal">Evidence</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {COMPANY_MAP.map(([priority, company, category, verify]) => (
-                      <tr key={company} className="border-t border-white/10 align-top">
-                        <td className="p-4 font-mono text-xs text-lit-orange-700">{priority}</td>
-                        <td className="p-4 text-[0.95rem] font-medium text-white">{company}</td>
-                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{category}</td>
-                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{verify}</td>
+                    {PROOF_POINTS.map(([claim, evidence]) => (
+                      <tr key={claim} className="border-t border-white/10 align-top">
+                        <td className="p-4 text-[0.95rem] font-medium text-white">{claim}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{evidence}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -344,34 +373,23 @@ export default function SolversReport() {
               </figure>
             </section>
 
-            <section id="sec-outreach" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="7" id="outreach" title="Outreach workflow" />
+            <section id="sec-open-questions" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="8" id="open-questions" title="Open questions" />
               <P>
-                The report should open doors as a credible industry artifact. The recommended motion is to ask each team to verify the technical section about them before pitching any Lit-specific integration.
+                The market is early enough that many important details remain unsettled. These questions will determine whether solver networks become open infrastructure, vertically integrated liquidity businesses, or something in between.
               </P>
-              <ol className="mt-4 space-y-3">
-                {[
-                  'Share the taxonomy and the company profile draft.',
-                  'Ask the team to correct onboarding, solver responsibilities, custody, latency, and standards claims.',
-                  'Incorporate corrections and mark which claims are verified versus inferred from public docs.',
-                  'Only then discuss the company-specific Lit hypothesis: inventory vault, quote signer, settlement signer, withdrawal policy, or rebalancing control.',
-                ].map((item, i) => (
-                  <li key={item} className="flex gap-3 text-[1.02rem] leading-[1.7] text-white/70">
-                    <span className="font-mono text-xs text-lit-orange-700">{i + 1}</span>
-                    <span>{item}</span>
+              <ul className="mt-4 space-y-3">
+                {OPEN_QUESTIONS.map((item) => (
+                  <li key={item} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange-700" />
+                    {item}
                   </li>
                 ))}
-              </ol>
-              <div className="mt-7 rounded-2xl border border-white/10 bg-white/[0.02] p-5">
-                <div className="font-mono text-[0.7rem] uppercase tracking-[0.18em] text-lit-orange">Draft ask</div>
-                <p className="mt-3 text-[0.95rem] leading-relaxed text-white/65">
-                  We are putting together an industry report on cross-chain solvers, fillers, RFQ makers, intent protocols, and solver-adjacent interoperability rails. We included a section on your team and want to make sure we describe your architecture accurately. Would someone technical be open to reviewing onboarding, custody, signer assumptions, latency constraints, order formats, and public/private docs boundaries?
-                </p>
-              </div>
+              </ul>
             </section>
 
             <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="8" id="references" title="References" />
+              <SectionHead n="9" id="references" title="References" />
               <ol className="mt-4 space-y-3">
                 {REFERENCES.map((r) => (
                   <li key={r.n} id={`ref-${r.n}`} className="scroll-mt-24 flex gap-3 text-[0.9rem] leading-relaxed text-white/60">
@@ -386,7 +404,7 @@ export default function SolversReport() {
                 ))}
               </ol>
               <p className="mt-10 border-t border-white/10 pt-5 font-mono text-[0.7rem] leading-relaxed text-white/30">
-                Informational only. This report summarizes public materials and first-pass research current to June 2026. Company sections should be verified with the teams before publication or outreach. Lit-specific deployment ideas are hypotheses until validated against each protocol’s actual production architecture.
+                Informational only. This report summarizes public materials and first-pass research current to June 2026. The solver market is changing quickly; production details such as solver participation, custody, latency budgets, and standards support should be treated as implementation-specific and subject to change.
               </p>
             </section>
           </article>

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -1,0 +1,397 @@
+'use client';
+
+import { Container } from '@mantine/core';
+import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Button } from '@/components/ui/Button';
+
+const DEPLOYMENT_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLScQ8dU09fbdRa6Al70rP9Bb-iX_CngnGl1U6_YFh7s0UyKgkQ/viewform';
+const SOLVER_VAULT_EXAMPLE =
+  'https://github.com/LIT-Protocol/chipotle/tree/main/examples/lit-solver-vault';
+
+const Fn = ({ n }: { n: number }) => (
+  <sup className="ml-px">
+    <a href={`#ref-${n}`} className="font-mono text-[0.6em] text-lit-orange transition-colors hover:text-gold-500">
+      [{n}]
+    </a>
+  </sup>
+);
+
+const SECTIONS = [
+  { id: 'market', n: '1', title: 'The market' },
+  { id: 'taxonomy', n: '2', title: 'Solver taxonomy' },
+  { id: 'techniques', n: '3', title: 'Execution patterns' },
+  { id: 'risks', n: '4', title: 'Control surfaces' },
+  { id: 'lit', n: '5', title: 'Where Lit fits' },
+  { id: 'map', n: '6', title: 'Company map' },
+  { id: 'outreach', n: '7', title: 'Outreach workflow' },
+  { id: 'references', n: '8', title: 'References' },
+];
+
+const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
+  { n: 1, text: 'Across docs, “Crosschain Intents” and intent architecture.', href: 'https://docs.across.to/guides/concepts/crosschain-intents' },
+  { n: 2, text: 'deBridge DLN documentation, protocol overview and order fulfillment flow.', href: 'https://docs.debridge.com/dln-details/overview/protocol-overview' },
+  { n: 3, text: 'Wormhole Settlement overview.', href: 'https://wormhole.com/docs/products/settlement/overview/' },
+  { n: 4, text: 'Squid Coral Intent Swaps and solver documentation.', href: 'https://docs.squidrouter.com/api-and-sdk-integration/coral-intent-swaps' },
+  { n: 5, text: 'UniswapX developer docs, overview and auction types.', href: 'https://developers.uniswap.org/docs/liquidity/uniswapx/overview' },
+  { n: 6, text: 'CoW Protocol docs, solvers and fair combinatorial auction.', href: 'https://docs.cow.fi/cow-protocol/concepts/introduction/solvers' },
+  { n: 7, text: 'LI.FI architecture and quote API documentation.', href: 'https://docs.li.fi/introduction/lifi-architecture/system-overview' },
+  { n: 8, text: 'Socket architecture and EIP-7683 documentation.', href: 'https://docs.socket.tech/eip7683/' },
+  { n: 9, text: 'ERC-7683: Cross Chain Intents standard.', href: 'https://eips.ethereum.org/EIPS/eip-7683' },
+  { n: 10, text: 'Lit Protocol v3 (Chipotle): TEE-based execution, on-chain key orchestration, and hardware attestation.', href: 'https://spark.litprotocol.com/introducing-lit-protocol-v3-chipotle/' },
+  { n: 11, text: 'Lit solver vault example in the Chipotle repository.', href: SOLVER_VAULT_EXAMPLE },
+];
+
+const TAXONOMY = [
+  {
+    category: 'Fast-fill solver networks',
+    examples: 'Across, deBridge DLN, Wormhole Settlement, Squid Coral, Relay.link',
+    technique: 'A filler fronts destination-chain value and later claims, unlocks, or settles against source-chain value.',
+    question: 'Where is destination inventory held, and which keys can move it before repayment is final?',
+  },
+  {
+    category: 'Dutch-auction resolvers',
+    examples: 'UniswapX, 1inch Fusion+',
+    technique: 'A signed order decays in price; resolvers choose when to fill and compete on timing, price, and inventory.',
+    question: 'Which checks happen before quoting, before filling, and before escrow settlement?',
+  },
+  {
+    category: 'Batch-auction solvers',
+    examples: 'CoW Protocol',
+    technique: 'Solvers compete to produce the best aggregate settlement for a batch of intents.',
+    question: 'Who constructs settlement calldata, who signs it, and how are hooks or external venues constrained?',
+  },
+  {
+    category: 'RFQ market makers',
+    examples: 'Hashflow, Bebop, 0x-style professional maker flows',
+    technique: 'Professional makers issue firm, short-lived quotes against private inventory.',
+    question: 'How are quote-signing keys, inventory thresholds, and stale-price failures controlled?',
+  },
+  {
+    category: 'Aggregators and chain-abstraction routers',
+    examples: 'LI.FI, Socket/Bungee, Squid, Enso',
+    technique: 'The product selects routes across bridges, DEXs, intent protocols, and executors.',
+    question: 'Does the system only return calldata, or does it operate relayers, executors, gas sponsors, or refund paths?',
+  },
+  {
+    category: 'Settlement and messaging rails',
+    examples: 'LayerZero, Axelar, Wormhole, Hyperlane, Chainlink CCIP, Circle CCTP, Stargate',
+    technique: 'Infrastructure that solvers use for messages, canonical transfers, attestations, and rebalancing.',
+    question: 'Which relayers, executors, attestations, or finality assumptions gate downstream solver actions?',
+  },
+];
+
+const TECHNIQUES = [
+  ['Order intake', 'User signs an intent, places an RFQ, deposits into escrow, or submits a bridgeable route.'],
+  ['Solver selection', 'A resolver, filler, maker, or route executor wins by price, speed, exclusivity, reputation, or auction rules.'],
+  ['Destination execution', 'The solver fronts funds, performs a swap, executes a call, or creates destination-side escrow.'],
+  ['Claim and settlement', 'The solver proves the source order, unlocks funds, receives repayment, or nets obligations through a clearing layer.'],
+  ['Rebalancing', 'Inventory is moved across chains, venues, or custody systems to prepare for the next fill.'],
+];
+
+const CONTROL_SURFACES = [
+  ['Inventory custody', 'Funds often sit in EOAs, smart accounts, vault contracts, protocol balances, or venue accounts. The critical question is not only where funds sit, but what runtime conditions are required before they can move.'],
+  ['Order reconstruction', 'Before a fill, claim, or rebalance, a solver must reconstruct source-chain events, bridge attestations, quote IDs, deadlines, recipients, token amounts, and replay constraints.'],
+  ['Latency budget', 'A 100 ms quote path cannot carry the same checks as a settlement, withdrawal, or rebalance path. Controls have to be placed at the right phase of the lifecycle.'],
+  ['Onboarding model', '“Solver” can mean permissionless filler, allowlisted resolver, private RFQ maker, bonded relayer, internal executor, or infrastructure node. Each carries different trust and sales motion.'],
+  ['Standards compatibility', 'ERC-7683 is creating a shared cross-chain intent language, but production systems still use many protocol-specific order formats and API payloads.'],
+];
+
+const LIT_FITS = [
+  ['Policy-gated inventory', 'Put solver inventory behind a vault or signing flow that releases funds only when a Lit Action verifies the order, route, amount, deadline, profitability, and risk limits.'],
+  ['Attested execution', 'Run authorization logic inside TEEs and produce evidence that the exact policy approved or denied a fill, claim, withdrawal, or rebalance.'],
+  ['Cross-chain source verification', 'Use Lit Actions to read source-chain state, bridge attestations, VAAs, CCTP messages, or settlement roots before signing a downstream action.'],
+  ['Role separation', 'Separate quote generation, strategy, execution, withdrawal, and emergency permissions so no single bot or operator has unilateral inventory authority.'],
+  ['Company-specific deployment', 'The right wedge differs by category: Across-style relayer fills, RFQ quote signing, CCTP rebalancing, and aggregator executor wallets need different policies.'],
+];
+
+const COMPANY_MAP = [
+  ['P0', 'Across', 'Fast-fill relayer network', 'Relayer inventory custody, exclusive flows, fill authorization latency.'],
+  ['P0', 'deBridge DLN', '0-TVL cross-chain order network', 'Taker/filler claim keys, order fulfillment flow, reserve custody.'],
+  ['P0', 'Wormhole Settlement / Mayan', 'Settlement and solver ecosystem', 'Solver curation, VAA/CCTP verification, fast auction constraints.'],
+  ['P0', '1inch Fusion+', 'Cross-chain Dutch-auction resolver network', 'Resolver keys, escrow flow, secret generation and reveal.'],
+  ['P0', 'Squid Coral', 'Intent swaps over Axelar', 'Solver participation model, quote signing, inventory risk.'],
+  ['P0', 'Relay.link', 'Managed fast bridging and execution API', 'Liquidity provider custody, signer modes, rebalancing paths.'],
+  ['P1', 'UniswapX', 'Dutch-auction filler system', 'Cross-chain filler inventory, RFQ paths, reactor settlement.'],
+  ['P1', 'CoW Protocol', 'Batch-auction solver network', 'Settlement signing, solver buffers, hooks, simulation.'],
+  ['P1', 'LI.FI', 'Aggregator and intent router', 'Executor roles, solver access, route-safety policies.'],
+  ['P1', 'Socket / Bungee', 'Chain-abstraction orchestration', 'Transmitters, EIP-7683 support, gas and refund control.'],
+  ['P1', 'Hashflow / Bebop', 'RFQ market-maker networks', 'Quote-signing keys, stale quotes, PMM inventory controls.'],
+  ['P2', 'Everclear', 'Clearing and netting layer', 'Solver rebalancing reduction, settlement responsibilities.'],
+];
+
+const P = ({ children }: { children: ReactNode }) => (
+  <p className="mt-4 text-[1.02rem] leading-[1.72] text-white/70">{children}</p>
+);
+
+const Lead = ({ children }: { children: ReactNode }) => <strong className="font-medium text-white">{children}</strong>;
+
+function SectionHead({ n, id, title }: { n: string; id: string; title: string }) {
+  return (
+    <div className="mb-2 flex items-baseline gap-3">
+      <span className="font-mono text-sm text-lit-orange-700">{n}</span>
+      <h2 className="text-[clamp(1.5rem,2.6vw,2rem)] font-medium leading-tight tracking-tight" id={id}>
+        {title}
+      </h2>
+    </div>
+  );
+}
+
+export default function SolversReport() {
+  const [active, setActive] = useState<string>('market');
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setActive((e.target as HTMLElement).id.replace('sec-', ''));
+        });
+      },
+      { rootMargin: '-20% 0px -70% 0px' }
+    );
+    SECTIONS.forEach((s) => {
+      const el = document.getElementById(`sec-${s.id}`);
+      if (el) obs.observe(el);
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div className="bg-coal-950 text-white">
+      <header className="relative overflow-hidden border-b border-white/10">
+        <div className="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[min(1000px,140vw)] -translate-x-1/2 -translate-y-1/3 blur-[10px] bg-[radial-gradient(ellipse_at_center,_oklch(53.51%_0.163_39.51/0.22)_0%,_transparent_64%)]" />
+        <Container size="lg" className="relative !pt-20 !pb-16 md:!pt-28">
+          <div className="font-mono text-xs uppercase tracking-[0.28em] text-lit-orange">Industry report</div>
+          <h1 className="mt-5 max-w-[18ch] text-[clamp(2.5rem,6.5vw,5rem)] font-medium leading-[1.0] tracking-tight">
+            Cross-Chain Solvers
+          </h1>
+          <p className="mt-5 max-w-[48ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
+            Market map, taxonomy, and control architecture for intent-based execution.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
+            <span>Version 0.1 · June 2026</span>
+            <span className="text-white/15">|</span>
+            <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
+          </div>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+              Discuss solver infrastructure
+            </Button>
+            <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
+              See the solver vault example
+            </Button>
+          </div>
+        </Container>
+      </header>
+
+      <Container size="lg" className="!py-16 md:!py-20">
+        <div className="mx-auto max-w-[44rem] rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
+          <div className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-lit-orange">Abstract</div>
+          <p className="text-[1.05rem] leading-[1.75] text-white/80">
+            Cross-chain solvers are the operators behind intent-based execution. They accept a user order on one domain and make the desired outcome happen on another by fronting destination-chain liquidity, performing swaps or calls, and later reclaiming value through a bridge, escrow, message layer, canonical asset rail, or clearing system. The market is converging around a small number of repeatable patterns, but each pattern exposes a hard operational problem: <Lead>who can move solver inventory, under what conditions, and how can that decision be verified?</Lead>
+          </p>
+        </div>
+
+        <div className="wp-grid mt-16 lg:grid lg:grid-cols-[200px_minmax(0,44rem)] lg:justify-center lg:gap-16">
+          <nav className="mb-10 hidden lg:block">
+            <div className="sticky top-24">
+              <div className="mb-4 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-white/40">Contents</div>
+              <ul className="space-y-2.5">
+                {SECTIONS.map((s) => (
+                  <li key={s.id}>
+                    <a
+                      href={`#sec-${s.id}`}
+                      className={`flex gap-2.5 text-sm transition-colors ${active === s.id ? 'text-lit-orange' : 'text-white/45 hover:text-white/80'}`}
+                    >
+                      <span className="font-mono text-xs opacity-60">{s.n}</span>
+                      {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </nav>
+
+          <article className="wp-doc max-w-[44rem]">
+            <section id="sec-market" className="scroll-mt-24">
+              <SectionHead n="1" id="market" title="The market" />
+              <P>
+                The cross-chain user experience is moving from “choose a bridge, choose a DEX, wait, then complete the trade” to <Lead>state the outcome and let a solver compete to deliver it</Lead>. The user signs an intent or creates an order; the solver decides whether the route is profitable and safe; the protocol enforces settlement.
+              </P>
+              <P>
+                This compresses UX and gives applications chain abstraction, but it also moves risk into solver infrastructure. Solvers need hot inventory, fast signatures, API credentials, bridge attestations, and settlement permissions spread across many chains. Their competitive advantage depends on speed, but their downside comes from letting the wrong transaction move inventory.
+              </P>
+            </section>
+
+            <section id="sec-taxonomy" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="2" id="taxonomy" title="Solver taxonomy" />
+              <P>The same word, “solver,” covers several different business and technical roles. A useful taxonomy starts with how the actor gets selected and how it is repaid.</P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-1/4 p-4 font-normal">Category</th>
+                      <th className="p-4 font-normal">Technique</th>
+                      <th className="p-4 font-normal">Control question</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TAXONOMY.map((r) => (
+                      <tr key={r.category} className="border-t border-white/10 align-top">
+                        <td className="p-4 text-[0.95rem] font-medium text-white">
+                          {r.category}
+                          <span className="mt-1 block text-xs font-normal leading-relaxed text-white/35">{r.examples}</span>
+                        </td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.technique}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.question}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+            </section>
+
+            <section id="sec-techniques" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="3" id="techniques" title="Execution patterns" />
+              <P>
+                Across Dutch auctions, RFQ, batch auctions, and fast-fill networks, the operational lifecycle repeats: take an order, select a solver, execute on the destination, claim on the source, then rebalance for the next trade.
+              </P>
+              <figure className="mt-7 rounded-2xl border border-dashed border-lit-orange/30 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.06),_transparent_60%)] px-5 pb-6 pt-9">
+                <span className="-mt-12 mb-1 block font-mono text-[0.7rem] tracking-wide text-lit-orange">Intent lifecycle · solver-controlled phases</span>
+                <div className="mt-3 grid gap-2.5">
+                  {TECHNIQUES.map(([title, body], i) => (
+                    <div key={title} className="flex items-start gap-4 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span className="w-6 shrink-0 pt-0.5 font-mono text-xs font-semibold text-lit-orange">{String(i + 1).padStart(2, '0')}</span>
+                      <div>
+                        <b className="block text-[0.95rem] font-medium">{title}</b>
+                        <span className="text-sm text-white/55">{body}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </figure>
+              <P>
+                ERC-7683 is an important step toward standard cross-chain intent order formats, with Across and Socket among the teams pushing explicit support.<Fn n={1} /><Fn n={8} /><Fn n={9} /> But today, many production systems still use project-specific escrow formats, RFQ payloads, API routes, or settlement contracts.
+              </P>
+            </section>
+
+            <section id="sec-risks" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="4" id="risks" title="Control surfaces" />
+              <P>The industry report is not only a map of protocols. It is a map of operational control surfaces that appear again and again across solver designs.</P>
+              <ul className="mt-4 space-y-4">
+                {CONTROL_SURFACES.map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange" />
+                    <Lead>{h}.</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section id="sec-lit" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="5" id="lit" title="Where Lit fits" />
+              <P>
+                Lit is not a bridge, DEX, or router. The wedge is narrower and more fundamental: <Lead>programmable, attestable signing for solver inventory and execution authority</Lead>. A solver can keep its strategy fast while moving sensitive actions behind code-enforced policy.
+              </P>
+              <ul className="mt-4 space-y-4">
+                {LIT_FITS.map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.55rem] font-mono text-lit-orange">◆</span>
+                    <Lead>{h}.</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>
+                The Chipotle repository already contains a solver vault example that demonstrates this shape: a vault releases inventory only when a Lit Action verifies the policy and authorizes the solver action.<Fn n={10} /><Fn n={11} />
+              </P>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+                  Talk through a solver design
+                </Button>
+                <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
+                  View example code
+                </Button>
+              </div>
+            </section>
+
+            <section id="sec-map" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="6" id="map" title="Company map" />
+              <P>
+                The first outreach list should focus on companies whose products already expose solver, filler, RFQ, or route-executor control surfaces. Each profile should verify the architecture before moving into a sales conversation.
+              </P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-16 p-4 font-normal">Priority</th>
+                      <th className="p-4 font-normal">Company / project</th>
+                      <th className="p-4 font-normal">Category</th>
+                      <th className="p-4 font-normal">Verify first</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {COMPANY_MAP.map(([priority, company, category, verify]) => (
+                      <tr key={company} className="border-t border-white/10 align-top">
+                        <td className="p-4 font-mono text-xs text-lit-orange-700">{priority}</td>
+                        <td className="p-4 text-[0.95rem] font-medium text-white">{company}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{category}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{verify}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+            </section>
+
+            <section id="sec-outreach" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="7" id="outreach" title="Outreach workflow" />
+              <P>
+                The report should open doors as a credible industry artifact. The recommended motion is to ask each team to verify the technical section about them before pitching any Lit-specific integration.
+              </P>
+              <ol className="mt-4 space-y-3">
+                {[
+                  'Share the taxonomy and the company profile draft.',
+                  'Ask the team to correct onboarding, solver responsibilities, custody, latency, and standards claims.',
+                  'Incorporate corrections and mark which claims are verified versus inferred from public docs.',
+                  'Only then discuss the company-specific Lit hypothesis: inventory vault, quote signer, settlement signer, withdrawal policy, or rebalancing control.',
+                ].map((item, i) => (
+                  <li key={item} className="flex gap-3 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="font-mono text-xs text-lit-orange-700">{i + 1}</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ol>
+              <div className="mt-7 rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+                <div className="font-mono text-[0.7rem] uppercase tracking-[0.18em] text-lit-orange">Draft ask</div>
+                <p className="mt-3 text-[0.95rem] leading-relaxed text-white/65">
+                  We are putting together an industry report on cross-chain solvers, fillers, RFQ makers, intent protocols, and solver-adjacent interoperability rails. We included a section on your team and want to make sure we describe your architecture accurately. Would someone technical be open to reviewing onboarding, custody, signer assumptions, latency constraints, order formats, and public/private docs boundaries?
+                </p>
+              </div>
+            </section>
+
+            <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="8" id="references" title="References" />
+              <ol className="mt-4 space-y-3">
+                {REFERENCES.map((r) => (
+                  <li key={r.n} id={`ref-${r.n}`} className="scroll-mt-24 flex gap-3 text-[0.9rem] leading-relaxed text-white/60">
+                    <span className="font-mono text-xs text-lit-orange-700">[{r.n}]</span>
+                    <span>
+                      {r.text}{' '}
+                      <a href={r.href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 whitespace-nowrap text-lit-orange transition-colors hover:text-gold-500">
+                        link <IconExternalLink size={11} stroke={2} className="opacity-70" />
+                      </a>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              <p className="mt-10 border-t border-white/10 pt-5 font-mono text-[0.7rem] leading-relaxed text-white/30">
+                Informational only. This report summarizes public materials and first-pass research current to June 2026. Company sections should be verified with the teams before publication or outreach. Lit-specific deployment ideas are hypotheses until validated against each protocol’s actual production architecture.
+              </p>
+            </section>
+          </article>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -18,14 +18,15 @@ const Fn = ({ n }: { n: number }) => (
 
 const SECTIONS = [
   { id: 'forcing-function', n: '1', title: 'The forcing function' },
-  { id: 'solver-role', n: '2', title: 'The solver role' },
-  { id: 'execution-models', n: '3', title: 'Execution models' },
-  { id: 'ecosystem', n: '4', title: 'The ecosystem' },
-  { id: 'fault-lines', n: '5', title: 'Operational fault lines' },
-  { id: 'verifiable-control', n: '6', title: 'Verifiable control' },
-  { id: 'proof', n: '7', title: 'What a solver can prove' },
-  { id: 'open-questions', n: '8', title: 'Open questions' },
-  { id: 'references', n: '9', title: 'References' },
+  { id: 'loss-pattern', n: '2', title: 'The loss pattern' },
+  { id: 'solver-role', n: '3', title: 'The solver role' },
+  { id: 'execution-models', n: '4', title: 'Execution models' },
+  { id: 'ecosystem', n: '5', title: 'The ecosystem' },
+  { id: 'fault-lines', n: '6', title: 'Operational fault lines' },
+  { id: 'verifiable-control', n: '7', title: 'Verifiable control' },
+  { id: 'proof', n: '8', title: 'What a solver can prove' },
+  { id: 'open-questions', n: '9', title: 'Open questions' },
+  { id: 'references', n: '10', title: 'References' },
 ];
 
 const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
@@ -38,8 +39,11 @@ const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
   { n: 7, text: 'LI.FI architecture and quote API documentation.', href: 'https://docs.li.fi/introduction/lifi-architecture/system-overview' },
   { n: 8, text: 'Socket architecture and EIP-7683 documentation.', href: 'https://docs.socket.tech/eip7683/' },
   { n: 9, text: 'ERC-7683: Cross Chain Intents standard.', href: 'https://eips.ethereum.org/EIPS/eip-7683' },
-  { n: 10, text: 'Lit Protocol v3 (Chipotle): TEE-based execution, on-chain key orchestration, and hardware attestation.', href: 'https://spark.litprotocol.com/introducing-lit-protocol-v3-chipotle/' },
-  { n: 11, text: 'Lit solver vault example in the Chipotle repository.', href: SOLVER_VAULT_EXAMPLE },
+  { n: 10, text: 'Chainalysis, “$2.2 Billion Stolen from Crypto Platforms in 2024” — 2024 stolen funds, centralized-service hacks, DMM Bitcoin and WazirX examples, and private-key compromise share.', href: 'https://www.chainalysis.com/blog/crypto-hacking-stolen-funds-2025/' },
+  { n: 11, text: 'TRM Labs, “$2.2 billion was stolen in crypto-related hacks in 2024” — threat-vector breakdown and private-key / seed-phrase compromise share.', href: 'https://www.trmlabs.com/resources/blog/category-deep-dive-2-2-billion-was-stolen-in-crypto-related-hacks-in-2024' },
+  { n: 12, text: 'TRM Labs, “Bybit Hack Update” — approximately $1.5B stolen and rapid laundering through DeFi and cross-chain services.', href: 'https://www.trmlabs.com/resources/blog/bybit-hack-update-north-korea-moves-to-next-stage-of-laundering' },
+  { n: 13, text: 'Lit Protocol v3 (Chipotle): TEE-based execution, on-chain key orchestration, and hardware attestation.', href: 'https://spark.litprotocol.com/introducing-lit-protocol-v3-chipotle/' },
+  { n: 14, text: 'Lit solver vault example in the Chipotle repository.', href: SOLVER_VAULT_EXAMPLE },
 ];
 
 const TAXONOMY = [
@@ -89,6 +93,33 @@ const TECHNIQUES = [
   ['Rebalancing', 'Inventory is moved across chains, venues, or custody systems to prepare for the next fill.'],
 ];
 
+const LOSS_STATS = [
+  {
+    value: '$2.2B',
+    label: 'stolen in 2024',
+    body: 'Chainalysis estimated $2.2B stolen from crypto platforms in 2024 across 303 incidents; TRM’s independent 2024 hack deep dive reports the same headline total.',
+    refs: [10, 11],
+  },
+  {
+    value: '44–70%',
+    label: 'tied to private keys',
+    body: 'Chainalysis attributed 43.8% of stolen 2024 value to private-key compromises; TRM attributed nearly 70% to infrastructure attacks, primarily private-key and seed-phrase compromises.',
+    refs: [10, 11],
+  },
+  {
+    value: '~$1.0–1.5B',
+    label: '2024 private-key loss range',
+    body: 'Applied to the $2.2B 2024 total, those two estimates imply roughly $964M to $1.54B of 2024 losses from private-key / seed-phrase style compromise.',
+    refs: [10, 11],
+  },
+  {
+    value: '$1.5B',
+    label: 'Bybit 2025 exploit',
+    body: 'TRM describes the February 2025 Bybit theft as approximately $1.5B in ETH tokens, with at least $160M moved through illicit channels within 48 hours and over $400M moved by February 26.',
+    refs: [12],
+  },
+];
+
 const CONTROL_SURFACES = [
   ['Inventory custody', 'Funds often sit in EOAs, smart accounts, vault contracts, protocol balances, or venue accounts. The critical question is not only where funds sit, but what runtime conditions are required before they can move.'],
   ['Order reconstruction', 'Before a fill, claim, or rebalance, a solver must reconstruct source-chain events, bridge attestations, quote IDs, deadlines, recipients, token amounts, and replay constraints.'],
@@ -103,6 +134,15 @@ const VERIFIABLE_CONTROLS = [
   ['Cross-chain source verification', 'Source-chain state, bridge attestations, VAAs, CCTP messages, or settlement roots can be checked before a downstream action is signed.'],
   ['Role separation', 'Quote generation, strategy, execution, withdrawal, and emergency permissions can be separated so no single bot or operator has unilateral inventory authority.'],
   ['Phase-aware controls', 'The controls used for quoting, filling, claiming, and rebalancing can differ according to each phase’s latency budget and risk profile.'],
+];
+
+const LIT_HELP = [
+  ['Hot-wallet drain prevention', 'A solver vault can require a Lit Action policy before inventory moves. If a bot server, API key, or ordinary operator credential is compromised, the attacker still cannot drain funds unless the order, route, limits, and chain facts satisfy policy.'],
+  ['Blast-radius limits', 'Policies can enforce per-token, per-chain, per-counterparty, per-route, and time-window limits so a single failure cannot become an unlimited cross-chain inventory drain.'],
+  ['Source-of-truth checks', 'Before signing a fill, claim, withdrawal, or rebalance, a Lit Action can reconstruct source-chain deposits, bridge attestations, CCTP messages, VAAs, deadlines, recipients, and replay state.'],
+  ['Phase-specific controls', 'Low-latency quote paths can stay fast, while higher-risk phases — destination release, claim, withdrawal, and rebalance — use stricter checks and attested approvals.'],
+  ['Emergency response', 'A policy can include kill switches, circuit breakers, allowlist changes, or governance-gated upgrades without handing a single hot key the power to move every asset.'],
+  ['Auditability', 'The solver can show which code path authorized or denied a movement of funds, turning key management from an operational promise into a verifiable control.'],
 ];
 
 const PROOF_POINTS = [
@@ -238,8 +278,29 @@ export default function SolversReport() {
               </P>
             </section>
 
+            <section id="sec-loss-pattern" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="2" id="loss-pattern" title="The loss pattern" />
+              <P>
+                The main risk for production solvers is not abstract bridge risk. It is inventory controlled by keys that must stay online enough to quote, fill, claim, withdraw, and rebalance. The broader crypto market shows how expensive that key-management layer can become when it fails.
+              </P>
+              <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                {LOSS_STATS.map((stat) => (
+                  <div key={stat.label} className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+                    <div className="text-[clamp(1.8rem,4vw,2.6rem)] font-semibold leading-none tracking-tight text-lit-orange">{stat.value}</div>
+                    <div className="mt-2 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-white/40">{stat.label}</div>
+                    <p className="mt-3 text-[0.9rem] leading-relaxed text-white/65">
+                      {stat.body}{stat.refs.map((n) => <Fn key={n} n={n} />)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <P>
+                A solver is not an exchange, but the failure mode rhymes: once a hot key can move valuable inventory, compromise turns directly into loss. For solver networks, the practical question is whether inventory-moving authority can be online enough to compete while still being constrained enough that a compromised bot cannot empty the vault.
+              </P>
+            </section>
+
             <section id="sec-solver-role" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="2" id="solver-role" title="The solver role" />
+              <SectionHead n="3" id="solver-role" title="The solver role" />
               <P>The same word, “solver,” covers several different business and technical roles. A useful taxonomy starts with how the actor gets selected and how it is repaid.</P>
               <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
                 <table className="w-full border-collapse text-left align-top">
@@ -267,7 +328,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-execution-models" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="3" id="execution-models" title="Execution models" />
+              <SectionHead n="4" id="execution-models" title="Execution models" />
               <P>
                 Across Dutch auctions, RFQ, batch auctions, and fast-fill networks, the operational lifecycle repeats: take an order, select a solver, execute on the destination, claim on the source, then rebalance for the next trade.
               </P>
@@ -291,7 +352,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-ecosystem" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="4" id="ecosystem" title="The ecosystem" />
+              <SectionHead n="5" id="ecosystem" title="The ecosystem" />
               <P>
                 The solver ecosystem is not a single market. It is a stack of relayers, resolvers, RFQ makers, routers, settlement systems, canonical transfer rails, and clearing layers. Some teams operate inventory directly; others coordinate execution or reduce settlement friction.
               </P>
@@ -318,7 +379,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-fault-lines" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="5" id="fault-lines" title="Operational fault lines" />
+              <SectionHead n="6" id="fault-lines" title="Operational fault lines" />
               <P>The state of solvers is defined as much by operational constraints as by protocol design. The same fault lines appear across otherwise different systems.</P>
               <ul className="mt-4 space-y-4">
                 {CONTROL_SURFACES.map(([h, b]) => (
@@ -331,7 +392,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-verifiable-control" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="6" id="verifiable-control" title="Verifiable control" />
+              <SectionHead n="7" id="verifiable-control" title="Verifiable control" />
               <P>
                 The control problem is not unique to any one protocol. A solver needs a way to move quickly without turning every hot wallet, executor, or quote signer into an unconstrained source of loss. The emerging answer is <Lead>programmable, attestable signing for solver inventory and execution authority</Lead>: sensitive actions can move behind code-enforced policy while strategy remains fast.
               </P>
@@ -344,12 +405,20 @@ export default function SolversReport() {
                 ))}
               </ul>
               <P>
-                One implementation pattern is to pair policy-gated signing with verifiable execution environments: the policy checks cross-chain facts, and the signing path produces evidence about the code and context that authorized the action. Lit’s solver vault example is included in the references as one concrete version of this architecture.<Fn n={10} /><Fn n={11} />
+                Lit is one implementation of this pattern. A Lit Action can run the policy check; Lit’s TEE-backed signing path can authorize the transaction only if the policy passes; and the solver can keep a record of what code and context approved the action.<Fn n={13} /><Fn n={14} />
               </P>
+              <ul className="mt-4 space-y-4">
+                {LIT_HELP.map(([h, b]) => (
+                  <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange" />
+                    <Lead>{h}.</Lead> {b}
+                  </li>
+                ))}
+              </ul>
             </section>
 
             <section id="sec-proof" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="7" id="proof" title="What a solver can prove" />
+              <SectionHead n="8" id="proof" title="What a solver can prove" />
               <P>
                 A mature solver stack should be able to show more than a transaction hash after the fact. It should be able to show why an action was allowed, why a risky action was denied, and which code path held authority over inventory.
               </P>
@@ -374,7 +443,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-open-questions" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="8" id="open-questions" title="Open questions" />
+              <SectionHead n="9" id="open-questions" title="Open questions" />
               <P>
                 The market is early enough that many important details remain unsettled. These questions will determine whether solver networks become open infrastructure, vertically integrated liquidity businesses, or something in between.
               </P>
@@ -389,7 +458,7 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="9" id="references" title="References" />
+              <SectionHead n="10" id="references" title="References" />
               <ol className="mt-4 space-y-3">
                 {REFERENCES.map((r) => (
                   <li key={r.n} id={`ref-${r.n}`} className="scroll-mt-24 flex gap-3 text-[0.9rem] leading-relaxed text-white/60">
@@ -404,7 +473,7 @@ export default function SolversReport() {
                 ))}
               </ol>
               <p className="mt-10 border-t border-white/10 pt-5 font-mono text-[0.7rem] leading-relaxed text-white/30">
-                Informational only. This report summarizes public materials and first-pass research current to June 2026. The solver market is changing quickly; production details such as solver participation, custody, latency budgets, and standards support should be treated as implementation-specific and subject to change.
+                Informational only. This report summarizes public materials and first-pass research current to June 2026. Loss estimates vary by source and attribution method; the figures above are directional and should be read as evidence of the magnitude of key-management risk, not as a legal or forensic conclusion. The solver market is changing quickly; production details such as solver participation, custody, latency budgets, and standards support should be treated as implementation-specific and subject to change.
               </p>
             </section>
           </article>

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -4,6 +4,7 @@ import { Container } from '@mantine/core';
 import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
 import { Fragment, useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/Button';
+import { CALENDAR_LINK } from '@/utils/constants';
 
 const SOLVER_VAULT_EXAMPLE =
   'https://github.com/LIT-Protocol/chipotle/tree/main/examples/lit-solver-vault';
@@ -229,11 +230,11 @@ export default function SolversReport() {
             <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
           </div>
           <div className="mt-9 flex flex-wrap gap-3">
-            <Button href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
-              See the solver vault example
+            <Button href={CALENDAR_LINK} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+              Book a solver security review
             </Button>
-            <Button variant="outline" href="#sec-solver-role">
-              Read the taxonomy
+            <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
+              See the solver vault example
             </Button>
           </div>
         </Container>
@@ -494,6 +495,25 @@ export default function SolversReport() {
                   </li>
                 ))}
               </ul>
+            </section>
+
+            <section className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <div className="rounded-2xl border border-lit-orange/25 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.10),_transparent_65%)] p-8 text-center md:p-12">
+                <h2 className="mx-auto max-w-[22ch] text-[clamp(1.6rem,3.4vw,2.4rem)] font-medium leading-tight tracking-tight">
+                  Keep the speed. Lose the unconstrained key.
+                </h2>
+                <p className="mx-auto mt-4 max-w-[50ch] text-[1.02rem] leading-relaxed text-white/65">
+                  If you operate solver inventory across chains, we’ll walk your team through policy-gated signing — and a working vault you can fork today.
+                </p>
+                <div className="mt-7 flex flex-wrap justify-center gap-3">
+                  <Button href={CALENDAR_LINK} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+                    Book a solver security review
+                  </Button>
+                  <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
+                    See the solver vault example
+                  </Button>
+                </div>
+              </div>
             </section>
 
             <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -227,8 +227,6 @@ export default function SolversReport() {
             A state-of-the-market survey of fillers, RFQ makers, intent routers, and settlement rails.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
-            <span>Version 0.1 · June 2026</span>
-            <span className="text-white/15">|</span>
             <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
           </div>
           <div className="mt-9 flex flex-wrap gap-3">

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -4,10 +4,12 @@ import { Container } from '@mantine/core';
 import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/Button';
-import { CALENDAR_LINK } from '@/utils/constants';
 
 const SOLVER_VAULT_EXAMPLE =
   'https://github.com/LIT-Protocol/chipotle/tree/main/examples/lit-solver-vault';
+
+const SOLVER_REVIEW_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLSeZ16PjwV7YZIvEuTwJ-7ijVb039SsIwVqkJyI2ffPdwkn6DQ/viewform';
 
 const Fn = ({ n }: { n: number }) => (
   <sup className="ml-px">
@@ -230,7 +232,7 @@ export default function SolversReport() {
             <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
           </div>
           <div className="mt-9 flex flex-wrap gap-3">
-            <Button href={CALENDAR_LINK} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+            <Button href={SOLVER_REVIEW_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
               Book a solver security review
             </Button>
             <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">
@@ -506,7 +508,7 @@ export default function SolversReport() {
                   If you operate solver inventory across chains, we’ll walk your team through policy-gated signing — and a working vault you can fork today.
                 </p>
                 <div className="mt-7 flex flex-wrap justify-center gap-3">
-                  <Button href={CALENDAR_LINK} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+                  <Button href={SOLVER_REVIEW_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
                     Book a solver security review
                   </Button>
                   <Button variant="outline" href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer">

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Container } from '@mantine/core';
-import { IconExternalLink } from '@tabler/icons-react';
-import { useEffect, useState, type ReactNode } from 'react';
+import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
+import { Fragment, useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/Button';
 
 const SOLVER_VAULT_EXAMPLE =
@@ -85,12 +85,12 @@ const TAXONOMY = [
   },
 ];
 
-const TECHNIQUES = [
-  ['Order intake', 'User signs an intent, places an RFQ, deposits into escrow, or submits a bridgeable route.'],
-  ['Solver selection', 'A resolver, filler, maker, or route executor wins by price, speed, exclusivity, reputation, or auction rules.'],
-  ['Destination execution', 'The solver fronts funds, performs a swap, executes a call, or creates destination-side escrow.'],
-  ['Claim and settlement', 'The solver proves the source order, unlocks funds, receives repayment, or nets obligations through a clearing layer.'],
-  ['Rebalancing', 'Inventory is moved across chains, venues, or custody systems to prepare for the next fill.'],
+const LIFECYCLE = [
+  { n: '01', title: 'Order intake', chain: 'Source chain', body: 'User signs an intent, places an RFQ, deposits into escrow, or submits a bridgeable route.', gated: false },
+  { n: '02', title: 'Solver selection', chain: 'Off-chain', body: 'A resolver, filler, maker, or route executor wins on price, speed, exclusivity, or auction rules.', gated: false },
+  { n: '03', title: 'Destination execution', chain: 'Destination', body: 'The solver fronts funds, swaps, or executes a call — its first inventory-moving signature.', gated: true },
+  { n: '04', title: 'Claim & settlement', chain: 'Source chain', body: 'The solver proves the source order and unlocks, claims, or nets repayment.', gated: true },
+  { n: '05', title: 'Rebalancing', chain: 'Cross-chain', body: 'Inventory is moved across chains and venues to prepare for the next fill.', gated: true },
 ];
 
 const LOSS_STATS = [
@@ -229,11 +229,11 @@ export default function SolversReport() {
             <span className="text-white/60">Fillers · RFQ makers · intent routers · settlement rails</span>
           </div>
           <div className="mt-9 flex flex-wrap gap-3">
-            <Button href="#sec-solver-role">
-              Read the taxonomy
+            <Button href={SOLVER_VAULT_EXAMPLE} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+              See the solver vault example
             </Button>
-            <Button variant="outline" href="#sec-references">
-              Read the references
+            <Button variant="outline" href="#sec-solver-role">
+              Read the taxonomy
             </Button>
           </div>
         </Container>
@@ -332,20 +332,29 @@ export default function SolversReport() {
               <P>
                 Across Dutch auctions, RFQ, batch auctions, and fast-fill networks, the operational lifecycle repeats: take an order, select a solver, execute on the destination, claim on the source, then rebalance for the next trade.
               </P>
-              <figure className="mt-7 rounded-2xl border border-dashed border-lit-orange/30 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.06),_transparent_60%)] px-5 pb-6 pt-9">
-                <span className="-mt-12 mb-1 block font-mono text-[0.7rem] tracking-wide text-lit-orange">Intent lifecycle · solver-controlled phases</span>
-                <div className="mt-3 grid gap-2.5">
-                  {TECHNIQUES.map(([title, body], i) => (
-                    <div key={title} className="flex items-start gap-4 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
-                      <span className="w-6 shrink-0 pt-0.5 font-mono text-xs font-semibold text-lit-orange">{String(i + 1).padStart(2, '0')}</span>
-                      <div>
-                        <b className="block text-[0.95rem] font-medium">{title}</b>
-                        <span className="text-sm text-white/55">{body}</span>
+              <figure className="mt-7">
+                <div className="flex flex-col gap-2.5 md:flex-row md:items-stretch md:gap-0">
+                  {LIFECYCLE.map((p, i) => (
+                    <Fragment key={p.n}>
+                      <div className={`flex-1 rounded-xl border p-4 ${p.gated ? 'border-lit-orange/40 bg-lit-orange/[0.06]' : 'border-white/10 bg-white/[0.02]'}`}>
+                        <div className="flex items-center justify-between">
+                          <span className="font-mono text-xs text-lit-orange">{p.n}</span>
+                          <span className="font-mono text-[0.58rem] uppercase tracking-[0.12em] text-white/40">{p.chain}</span>
+                        </div>
+                        <b className="mt-2.5 block text-sm font-medium">{p.title}</b>
+                        <span className="mt-1.5 block text-xs leading-relaxed text-white/55">{p.body}</span>
+                        {p.gated && (
+                          <span className="mt-3 inline-block rounded bg-lit-orange/15 px-2 py-0.5 font-mono text-[0.58rem] uppercase tracking-[0.12em] text-lit-orange">◆ solver signs</span>
+                        )}
                       </div>
-                    </div>
+                      {i < LIFECYCLE.length - 1 && (
+                        <span className="hidden shrink-0 items-center px-1.5 font-mono text-lit-orange-700 md:flex">→</span>
+                      )}
+                    </Fragment>
                   ))}
                 </div>
               </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Figure 1 — The cross-chain intent lifecycle. Phases 3–5 are where a solver’s keys move inventory — and where a compromised signer turns into a loss.</figcaption>
               <P>
                 ERC-7683 is an important step toward standard cross-chain intent order formats, with Across and Socket among the teams pushing explicit support.<Fn n={1} /><Fn n={8} /><Fn n={9} /> But today, many production systems still use project-specific escrow formats, RFQ payloads, API routes, or settlement contracts.
               </P>
@@ -407,7 +416,37 @@ export default function SolversReport() {
               <P>
                 Lit is one implementation of this pattern. A Lit Action can run the policy check; Lit’s TEE-backed signing path can authorize the transaction only if the policy passes; and the solver can keep a record of what code and context approved the action.<Fn n={13} /><Fn n={14} />
               </P>
-              <ul className="mt-4 space-y-4">
+              <figure className="mt-7">
+                <div className="grid items-stretch gap-3 md:grid-cols-[1fr_auto_1.3fr_auto_1fr]">
+                  <div className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+                    <div className="font-mono text-[0.62rem] uppercase tracking-[0.14em] text-white/40">Fast path</div>
+                    <b className="mt-2 block text-[0.95rem] font-medium">Solver strategy &amp; bots</b>
+                    <span className="mt-1 block text-xs leading-relaxed text-white/55">Hot keys, API credentials, quote signers — competing on speed.</span>
+                  </div>
+                  <span className="hidden items-center justify-center font-mono text-lit-orange-700 md:flex">→</span>
+                  <div className="rounded-xl border border-dashed border-lit-orange/40 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.08),_transparent_60%)] p-5">
+                    <div className="font-mono text-[0.62rem] uppercase tracking-[0.14em] text-lit-orange">Policy gate · Lit Action in a TEE</div>
+                    <span className="mt-2 block text-xs text-white/70">Before any inventory move, verify:</span>
+                    <ul className="mt-2 space-y-1 text-xs text-white/60">
+                      <li>◆ order, route, amount, deadline</li>
+                      <li>◆ per-token / per-chain / per-window limits</li>
+                      <li>◆ source of truth — deposits, VAAs, CCTP, replay state</li>
+                    </ul>
+                    <div className="mt-3 flex flex-wrap gap-2 font-mono text-[0.62rem]">
+                      <span className="rounded bg-lit-orange/15 px-2 py-1 text-lit-orange">pass → sign</span>
+                      <span className="rounded bg-white/5 px-2 py-1 text-white/40">fail → no signature</span>
+                    </div>
+                  </div>
+                  <span className="hidden items-center justify-center font-mono text-lit-orange-700 md:flex">→</span>
+                  <div className="rounded-xl border border-white/10 bg-white/[0.02] p-5">
+                    <div className="font-mono text-[0.62rem] uppercase tracking-[0.14em] text-white/40">Protected</div>
+                    <b className="mt-2 block text-[0.95rem] font-medium">Solver inventory</b>
+                    <span className="mt-1 block text-xs leading-relaxed text-white/55">Vaults &amp; balances across chains — move only on a verified signature.</span>
+                  </div>
+                </div>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Figure 2 — A policy gate in front of inventory-moving signatures. Strategy stays fast; the signature is withheld unless code verifies the order, route, limits, and chain facts.</figcaption>
+              <ul className="mt-6 space-y-4">
                 {LIT_HELP.map(([h, b]) => (
                   <li key={h} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
                     <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange" />

--- a/src/app/solvers/_components/SolversReport.tsx
+++ b/src/app/solvers/_components/SolversReport.tsx
@@ -2,7 +2,7 @@
 
 import { Container } from '@mantine/core';
 import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
-import { Fragment, useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/Button';
 import { CALENDAR_LINK } from '@/utils/constants';
 
@@ -26,7 +26,7 @@ const SECTIONS = [
   { id: 'fault-lines', n: '6', title: 'Operational fault lines' },
   { id: 'verifiable-control', n: '7', title: 'Verifiable control' },
   { id: 'proof', n: '8', title: 'What a solver can prove' },
-  { id: 'open-questions', n: '9', title: 'Open questions' },
+  { id: 'open-questions', n: '9', title: 'Questions worth asking' },
   { id: 'references', n: '10', title: 'References' },
 ];
 
@@ -169,11 +169,11 @@ const ECOSYSTEM = [
 ];
 
 const OPEN_QUESTIONS = [
-  'Which solver roles are actually permissionless today, and which remain allowlisted or relationship-driven?',
-  'How much policy checking can happen before quote, before fill, before claim, and before rebalance without breaking latency?',
-  'Will ERC-7683 become the common order format, or will production systems continue to use protocol-specific payloads?',
-  'Where should risk live: in solver bots, vault contracts, TEEs, multisigs, optimistic dispute systems, or clearing layers?',
-  'How should users and applications evaluate solver reliability when fills are fast but settlement and rebalancing happen later?',
+  'If a bot server or API key is compromised, can it still move inventory — or does code gate every transfer first?',
+  'Can you prove a risky or invalid fill was denied, not just that nothing bad happened to occur?',
+  'Is inventory-moving authority separated from strategy and quoting, or does one hot key do everything?',
+  'Before a claim, withdrawal, or rebalance, what reconstructs source-chain truth — and what happens if it is wrong?',
+  'Could you show an auditor, a partner, or a user exactly which code path authorized a movement of funds?',
 ];
 
 const P = ({ children }: { children: ReactNode }) => (
@@ -334,24 +334,24 @@ export default function SolversReport() {
                 Across Dutch auctions, RFQ, batch auctions, and fast-fill networks, the operational lifecycle repeats: take an order, select a solver, execute on the destination, claim on the source, then rebalance for the next trade.
               </P>
               <figure className="mt-7">
-                <div className="flex flex-col gap-2.5 md:flex-row md:items-stretch md:gap-0">
+                <div className="overflow-hidden rounded-2xl border border-white/10">
                   {LIFECYCLE.map((p, i) => (
-                    <Fragment key={p.n}>
-                      <div className={`flex-1 rounded-xl border p-4 ${p.gated ? 'border-lit-orange/40 bg-lit-orange/[0.06]' : 'border-white/10 bg-white/[0.02]'}`}>
-                        <div className="flex items-center justify-between">
-                          <span className="font-mono text-xs text-lit-orange">{p.n}</span>
-                          <span className="font-mono text-[0.58rem] uppercase tracking-[0.12em] text-white/40">{p.chain}</span>
+                    <div
+                      key={p.n}
+                      className={`flex items-start gap-4 p-4 md:gap-5 md:p-5 ${i > 0 ? 'border-t border-white/10' : ''} ${p.gated ? 'bg-lit-orange/[0.05]' : 'bg-white/[0.02]'}`}
+                    >
+                      <span className="w-8 shrink-0 pt-0.5 font-mono text-sm font-semibold text-lit-orange">{p.n}</span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+                          <b className="text-[0.95rem] font-medium">{p.title}</b>
+                          <span className="font-mono text-[0.58rem] uppercase tracking-[0.14em] text-white/40">{p.chain}</span>
+                          {p.gated && (
+                            <span className="rounded bg-lit-orange/15 px-2 py-0.5 font-mono text-[0.55rem] uppercase tracking-[0.12em] text-lit-orange">◆ solver signs</span>
+                          )}
                         </div>
-                        <b className="mt-2.5 block text-sm font-medium">{p.title}</b>
-                        <span className="mt-1.5 block text-xs leading-relaxed text-white/55">{p.body}</span>
-                        {p.gated && (
-                          <span className="mt-3 inline-block rounded bg-lit-orange/15 px-2 py-0.5 font-mono text-[0.58rem] uppercase tracking-[0.12em] text-lit-orange">◆ solver signs</span>
-                        )}
+                        <span className="mt-1.5 block text-sm leading-relaxed text-white/55">{p.body}</span>
                       </div>
-                      {i < LIFECYCLE.length - 1 && (
-                        <span className="hidden shrink-0 items-center px-1.5 font-mono text-lit-orange-700 md:flex">→</span>
-                      )}
-                    </Fragment>
+                    </div>
                   ))}
                 </div>
               </figure>
@@ -483,9 +483,9 @@ export default function SolversReport() {
             </section>
 
             <section id="sec-open-questions" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
-              <SectionHead n="9" id="open-questions" title="Open questions" />
+              <SectionHead n="9" id="open-questions" title="Questions worth asking" />
               <P>
-                The market is early enough that many important details remain unsettled. These questions will determine whether solver networks become open infrastructure, vertically integrated liquidity businesses, or something in between.
+                Whether you run solver inventory or depend on one, these are the questions that separate a controlled stack from a hopeful one — and the ones a policy-gated signing layer is built to answer.
               </P>
               <ul className="mt-4 space-y-3">
                 {OPEN_QUESTIONS.map((item) => (

--- a/src/app/solvers/opengraph-image.tsx
+++ b/src/app/solvers/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from 'next/server';
 
 export const runtime = 'edge';
 export const alt =
-  'Cross-Chain Solvers — a Lit Protocol industry report on solver networks, intent routing, and programmable custody.';
+  'Cross-Chain Solvers — a Lit Protocol position paper on solver networks, intent routing, and programmable custody.';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -69,7 +69,7 @@ export default function Image() {
               display: 'flex',
             }}
           />
-          LIT PROTOCOL · INDUSTRY REPORT
+          LIT PROTOCOL · POSITION PAPER
         </div>
 
         <div

--- a/src/app/solvers/opengraph-image.tsx
+++ b/src/app/solvers/opengraph-image.tsx
@@ -1,0 +1,120 @@
+import { ImageResponse } from 'next/server';
+
+export const runtime = 'edge';
+export const alt =
+  'Cross-Chain Solvers — a Lit Protocol industry report on solver networks, intent routing, and programmable custody.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '84px',
+          background: '#0b0806',
+          color: 'white',
+          position: 'relative',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: -180,
+            right: -160,
+            width: 680,
+            height: 680,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,91,41,0.24) 0%, transparent 62%)',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: -220,
+            left: -180,
+            width: 620,
+            height: 620,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,206,94,0.12) 0%, transparent 62%)',
+          }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: 24,
+            letterSpacing: '0.28em',
+            color: '#ff8a3d',
+            marginBottom: 30,
+            fontFamily: 'monospace',
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 999,
+              background: '#ff5b29',
+              display: 'flex',
+            }}
+          />
+          LIT PROTOCOL · INDUSTRY REPORT
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 104,
+            fontWeight: 600,
+            letterSpacing: '-0.04em',
+            lineHeight: 0.95,
+            maxWidth: 940,
+          }}
+        >
+          Cross-Chain Solvers
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 34,
+            color: 'rgba(246,237,226,0.72)',
+            marginTop: 28,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          Market map, taxonomy, and control architecture for intent-based execution.
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginTop: 60,
+            color: 'rgba(255,255,255,0.5)',
+            fontSize: 24,
+            fontFamily: 'monospace',
+            letterSpacing: '0.12em',
+          }}
+        >
+          <span style={{ display: 'flex' }}>litprotocol.com/solvers</span>
+          <span style={{ display: 'flex' }}>INTENTS · FILLERS · SETTLEMENT</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/solvers/page.tsx
+++ b/src/app/solvers/page.tsx
@@ -4,15 +4,15 @@ import SolversReport from './_components/SolversReport';
 
 const URL = 'https://litprotocol.com/solvers';
 const DESCRIPTION =
-  'An industry report on cross-chain solvers: fillers, RFQ makers, intent routers, settlement rails, operational risk, and where programmable policy can improve solver infrastructure.';
+  'A position paper on cross-chain solvers: fillers, RFQ makers, intent routers, settlement rails, operational risk, and where programmable policy can improve solver infrastructure.';
 
 export const metadata: Metadata = {
-  title: 'Cross-Chain Solvers: Industry Report | Lit Protocol',
+  title: 'Cross-Chain Solvers: A Position Paper | Lit Protocol',
   description: DESCRIPTION,
   alternates: { canonical: '/solvers' },
   openGraph: {
     type: 'article',
-    title: 'Cross-Chain Solvers — Industry Report',
+    title: 'Cross-Chain Solvers — A Position Paper',
     description: DESCRIPTION,
     url: URL,
     siteName: 'Lit Protocol',
@@ -31,7 +31,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
   headline: 'Cross-Chain Solvers',
-  alternativeHeadline: 'Industry Market Map and Taxonomy',
+  alternativeHeadline: 'A position paper on cross-chain solver infrastructure',
   description: DESCRIPTION,
   inLanguage: 'en',
   datePublished: '2026-06-02',

--- a/src/app/solvers/page.tsx
+++ b/src/app/solvers/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import PaperLayout from '../stablecoins/_components/PaperLayout';
+import SolversReport from './_components/SolversReport';
+
+const URL = 'https://litprotocol.com/solvers';
+const DESCRIPTION =
+  'An industry report on cross-chain solvers: fillers, RFQ makers, intent routers, settlement rails, operational risk, and where programmable policy can improve solver infrastructure.';
+
+export const metadata: Metadata = {
+  title: 'Cross-Chain Solvers: Industry Report | Lit Protocol',
+  description: DESCRIPTION,
+  alternates: { canonical: '/solvers' },
+  openGraph: {
+    type: 'article',
+    title: 'Cross-Chain Solvers — Industry Report',
+    description: DESCRIPTION,
+    url: URL,
+    siteName: 'Lit Protocol',
+    publishedTime: '2026-06-02T00:00:00.000Z',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Cross-Chain Solvers — Lit Protocol',
+    description: DESCRIPTION,
+    creator: '@LitProtocol',
+  },
+  robots: { index: true, follow: true },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Cross-Chain Solvers',
+  alternativeHeadline: 'Industry Market Map and Taxonomy',
+  description: DESCRIPTION,
+  inLanguage: 'en',
+  datePublished: '2026-06-02',
+  dateModified: '2026-06-02',
+  author: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    url: 'https://litprotocol.com',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://litprotocol.com/lit-logo.png',
+    },
+  },
+  mainEntityOfPage: URL,
+  image: 'https://litprotocol.com/solvers/opengraph-image',
+  about: [
+    'cross-chain solvers',
+    'intents',
+    'cross-chain swaps',
+    'chain abstraction',
+    'solver infrastructure',
+  ],
+};
+
+export default function SolversPage() {
+  return (
+    <PaperLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <SolversReport />
+    </PaperLayout>
+  );
+}

--- a/src/app/stablecoins/_components/WhitePaper.tsx
+++ b/src/app/stablecoins/_components/WhitePaper.tsx
@@ -121,8 +121,6 @@ export default function WhitePaper() {
             Code-enforced control for regulated stablecoins and tokenized assets.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
-            <span>Version 1.0 · June 2026</span>
-            <span className="text-white/15">|</span>
             <span className="text-white/60">
               GENIUS Act takes effect in <Countdown compact /> — January 18, 2027
             </span>


### PR DESCRIPTION
## Summary
- Adds a new `/solvers` industry-report page using the same dark editorial report styling as `/stablecoins`
- Adapts the cross-chain solver taxonomy/report into web-native sections: market overview, solver taxonomy, execution patterns, control surfaces, Lit fit, company map, outreach workflow, and references
- Adds route metadata, structured JSON-LD, a bespoke Open Graph image, and sitemap entry

## Validation
- `npm run lint` passes with existing warnings only
- `GHOST_ADMIN_API_KEY=<valid dummy format> npm run build` passes; build still logs pre-existing external env/API warnings for Ghost content and Dune, but `/solvers` compiles and is emitted as a static route
- Local browser smoke test at `http://localhost:3024/solvers`
- Visual inspection confirms the page matches the `/stablecoins` report style

## Notes
- Default `npm run build` fails locally if `GHOST_ADMIN_API_KEY` is unset because `/api/subscribe` initializes Ghost Admin at module load. I reran with a format-valid dummy key to validate this branch.
- No secrets were added.
