### PR TITLE
Landing page: deep-dive links, footer use-cases, CTA + nit polish

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -54,7 +54,7 @@ const Footer = () => {
             </a>
           </div>
           {/* Improved responsive grid layout */}
-          <div className="flex-1 grid gap-6 text-white grid-cols-2 sm:grid-cols-2 md:grid-cols-4 lg:gap-8">
+          <div className="flex-1 grid gap-6 text-white grid-cols-2 sm:grid-cols-2 md:grid-cols-5 lg:gap-8">
             <div className="flex flex-col gap-3">
               <h6 className={styles.footer__category}>Resources</h6>
               <a
@@ -104,6 +104,15 @@ const Footer = () => {
                 className={styles.footer__link}
               >
                 Governance
+              </a>
+            </div>
+            <div className="flex flex-col gap-3">
+              <h6 className={styles.footer__category}>Use cases</h6>
+              <a href="/stablecoins" className={styles.footer__link}>
+                Stablecoins
+              </a>
+              <a href="/solvers" className={styles.footer__link}>
+                Solvers
               </a>
             </div>
             <div className="flex flex-col gap-3">

--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -67,7 +67,7 @@ const LandingHero = () => {
         </div>
 
         <div className="mt-20 max-w-4xl mx-auto">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-2 md:gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
             <Pillar label="READ" sub="APIs · RPCs · feeds · prices" />
             <PillarCenter />
             <Pillar label="WRITE" sub="EVM · SVM · BTC · Cosmos · HTTPS" />

--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Container } from '@mantine/core';
+import Link from 'next/link';
 import { Button } from '../ui/Button';
 import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { CONTACT_FORM, DOCS_LINK } from '@/utils/constants';
@@ -66,6 +67,19 @@ const patterns = [
     k: 'Compliance-gated transfers',
     v: 'Lit Action screens every recipient against a sanctions list before signing — flagged wallets simply can’t receive.',
     href: `${EXAMPLES_BASE}/compliance-transfer-gate`,
+  },
+];
+
+const deepDives = [
+  {
+    k: 'Verifiable compliance for stablecoins',
+    v: 'Code-enforced, on-chain key control that satisfies the GENIUS Act — and your own auditors.',
+    href: '/stablecoins',
+  },
+  {
+    k: 'Cross-chain solvers',
+    v: 'A policy gate in a TEE that signs only the inventory moves your rules allow.',
+    href: '/solvers',
   },
 ];
 
@@ -175,6 +189,33 @@ const LandingHowItWorks = () => {
                   <div className="text-white/60 text-sm mt-1">{p.v}</div>
                 </div>
               </a>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      {/* DEEP DIVES */}
+      <section className="border-b border-white/5">
+        <Container size="lg" className="!py-28">
+          <div className="text-center mb-14 max-w-3xl mx-auto">
+            <Badge>Deep dives</Badge>
+            <h2 className="mt-5 text-4xl md:text-5xl font-medium">
+              Where this matters most.
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-2 gap-4 max-w-5xl mx-auto">
+            {deepDives.map((d) => (
+              <Link
+                key={d.href}
+                href={d.href}
+                className="rounded-xl border border-white/10 p-6 flex items-start gap-4 hover:border-mint-500/40 transition bg-white/[0.02] no-underline text-inherit"
+              >
+                <div className="font-mono text-mint-500 text-sm mt-1">→</div>
+                <div>
+                  <div className="font-medium text-lg">{d.k}</div>
+                  <div className="text-white/60 text-sm mt-1">{d.v}</div>
+                </div>
+              </Link>
             ))}
           </div>
         </Container>

--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -13,14 +13,30 @@ const Badge = ({ children }: { children: React.ReactNode }) => (
   </span>
 );
 
-const Stat = ({ k, v }: { k: string; v: string }) => (
-  <div className="border border-white/10 rounded-lg p-4 bg-white/[0.02]">
-    <div className="font-mono text-[10px] uppercase tracking-widest text-white/40">
-      {k}
+const Stat = ({ k, v, href }: { k: string; v: string; href?: string }) => {
+  const body = (
+    <>
+      <div className="font-mono text-[10px] uppercase tracking-widest text-white/40">
+        {k}
+      </div>
+      <div className="mt-2 text-sm">{v}</div>
+    </>
+  );
+  return href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="border border-white/10 rounded-lg p-4 bg-white/[0.02] block no-underline text-inherit hover:border-mint-500/40 transition"
+    >
+      {body}
+    </a>
+  ) : (
+    <div className="border border-white/10 rounded-lg p-4 bg-white/[0.02]">
+      {body}
     </div>
-    <div className="mt-2 text-sm">{v}</div>
-  </div>
-);
+  );
+};
 
 const codeSample = `// Inside a Lit Action — runs in a chain-secured TEE
 
@@ -46,6 +62,8 @@ if (Number(price.data.amount) * Number(ratio) < threshold) {
 
 const EXAMPLES_BASE =
   'https://github.com/LIT-Protocol/chipotle/tree/main/examples';
+
+const PRICING_DOCS = 'https://developer.litprotocol.com/management/pricing';
 
 const patterns = [
   {
@@ -158,7 +176,7 @@ const LandingHowItWorks = () => {
             <div className="grid grid-cols-2 gap-4">
               <Stat k="Latency" v="Sub-second signing" />
               <Stat k="Auditability" v="Code hash on-chain" />
-              <Stat k="Pricing" v="$0.01 per second" />
+              <Stat k="Pricing" v="$0.01 per second" href={PRICING_DOCS} />
               <Stat k="Surface" v="Any HTTP, any chain" />
             </div>
           </div>

--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -230,9 +230,6 @@ const LandingHowItWorks = () => {
               >
                 <div className="font-mono text-mint-500 text-sm mt-1">→</div>
                 <div>
-                  <div className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-mint-500/80 mb-1.5">
-                    Position paper
-                  </div>
                   <div className="font-medium text-lg">{d.k}</div>
                   <div className="text-white/60 text-sm mt-1">{d.v}</div>
                 </div>

--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -16,7 +16,7 @@ const Badge = ({ children }: { children: React.ReactNode }) => (
 const Stat = ({ k, v, href }: { k: string; v: string; href?: string }) => {
   const body = (
     <>
-      <div className="font-mono text-[10px] uppercase tracking-widest text-white/40">
+      <div className="font-mono text-[11px] uppercase tracking-widest text-white/40">
         {k}
       </div>
       <div className="mt-2 text-sm">{v}</div>
@@ -113,7 +113,7 @@ const LandingHowItWorks = () => {
               One file. Reads, computes, signs across chains.
             </h2>
             <p className="mt-6 text-white/70 text-lg">
-              A Lit Action is JavaScript that runs inside the network&apos;s
+              A Lit Action is JavaScript that runs inside the network’s
               TEE. Deploy it once. Sign with a wallet bound to the action code
               itself, or with one you control through your own on-chain
               governance.
@@ -121,11 +121,8 @@ const LandingHowItWorks = () => {
           </div>
 
           <div className="max-w-3xl mx-auto rounded-xl border border-white/10 bg-black/60 overflow-hidden shadow-2xl">
-            <div className="flex items-center gap-2 px-4 py-2 border-b border-white/10 bg-white/[0.02]">
-              <span className="w-2.5 h-2.5 rounded-full bg-red-400/60" />
-              <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/60" />
-              <span className="w-2.5 h-2.5 rounded-full bg-green-400/60" />
-              <span className="ml-3 text-xs font-mono text-white/40">
+            <div className="flex items-center px-4 py-2 border-b border-white/10 bg-white/[0.02]">
+              <span className="text-xs font-mono text-white/40">
                 rebalance.action.ts
               </span>
             </div>
@@ -149,11 +146,11 @@ const LandingHowItWorks = () => {
               Most cross-chain infra forces a tradeoff: trust a multisig, or
               wait for slow consensus on every read. Lit takes a different
               path. Code runs inside a TEE — an enclave the hardware itself
-              cryptographically attests to. Keys never leave. Logs can&apos;t
+              cryptographically attests to. Keys never leave. Logs can’t
               be rewritten.
             </p>
             <p className="mt-4 text-white/70 text-lg leading-relaxed">
-              The TEE&apos;s identity, its allowed code, and its signing
+              The TEE’s identity, its allowed code, and its signing
               authority are all governed on-chain. You get the speed and
               expressiveness of a single trusted runtime, with the
               auditability and on-chain governability of a smart contract.
@@ -164,7 +161,7 @@ const LandingHowItWorks = () => {
 
       {/* PROPERTIES */}
       <section className="border-b border-white/5">
-        <Container size="lg" className="!py-24">
+        <Container size="lg" className="!py-28">
           <div className="grid md:grid-cols-2 gap-16 items-start">
             <div>
               <Badge>The properties</Badge>

--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -212,6 +212,9 @@ const LandingHowItWorks = () => {
               >
                 <div className="font-mono text-mint-500 text-sm mt-1">→</div>
                 <div>
+                  <div className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-mint-500/80 mb-1.5">
+                    Position paper
+                  </div>
                   <div className="font-medium text-lg">{d.k}</div>
                   <div className="text-white/60 text-sm mt-1">{d.v}</div>
                 </div>
@@ -239,7 +242,7 @@ const LandingHowItWorks = () => {
               rel="noopener noreferrer"
               rightIcon={<IconArrowNarrowRight stroke={2} />}
             >
-              Read the docs
+              Start building
             </Button>
             <Button
               variant="outline"
@@ -247,7 +250,7 @@ const LandingHowItWorks = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              Get in touch
+              Talk to an engineer
             </Button>
           </div>
         </Container>

--- a/src/components/LandingPage/LandingPage.tsx
+++ b/src/components/LandingPage/LandingPage.tsx
@@ -8,7 +8,7 @@ const LandingPage = () => {
     <div className="overflow-x-hidden relative min-h-full bg-coal-950 text-off-white">
       <LandingHero />
       <section className="bg-coal-950 border-b border-white/5">
-        <Container size="lg" className="!py-20">
+        <Container size="lg" className="!py-24">
           <QuoteCarousel />
         </Container>
       </section>

--- a/src/components/QuoteCarousel/QuoteCarousel.tsx
+++ b/src/components/QuoteCarousel/QuoteCarousel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Carousel } from '@mantine/carousel';
-import { Group, Image, Card, Text } from '@mantine/core';
+import { Image, Card, Text } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { Button } from '../ui/Button';
 import {


### PR DESCRIPTION
Adds links to the two position-paper pages from the landing page, in two places:

- **Landing page** — a new **"Deep dives"** row right after "Patterns shipping today", with two cards → Verifiable Compliance (`/stablecoins`) and Cross-Chain Solvers (`/solvers`). Styled to match the existing pattern cards (mint accent), using internal `<Link>` navigation.
- **Footer** — a new **"Use cases"** column (Stablecoins · Solvers) for persistent, sitewide access. Footer grid widened from 4 → 5 columns.

Built green locally with `next build`. SSR confirms both links present in each location (2× `/stablecoins`, 2× `/solvers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
