### PR TITLE
Add a "Use cases" nav dropdown (Stablecoins, Solvers)

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -30,6 +30,14 @@ interface LinkItem {
 
 const links: LinkItem[] = [
   {
+    link: '/stablecoins',
+    label: 'Use cases',
+    links: [
+      { link: '/stablecoins', label: 'Stablecoins', external: false },
+      { link: '/solvers', label: 'Solvers', external: false },
+    ],
+  },
+  {
     link: DEVELOPER_CONSTANT_LINK,
     label: 'Developers',
     links: [

--- a/src/components/NavMenu/NavMenu2.tsx
+++ b/src/components/NavMenu/NavMenu2.tsx
@@ -21,6 +21,14 @@ interface LinkItem {
 
 const links: LinkItem[] = [
   {
+    link: '#use-cases',
+    label: 'Use cases',
+    links: [
+      { link: '/stablecoins', label: 'Stablecoins', external: false },
+      { link: '/solvers', label: 'Solvers', external: false },
+    ],
+  },
+  {
     link: '#dev',
     label: 'Developers',
     links: [


### PR DESCRIPTION
Adds a **"Use cases"** dropdown to the nav (first item), linking the two position papers — `/stablecoins` and `/solvers`.

- **Desktop** (`Header.tsx`): "Use cases ▾" before Developers, matching the existing dropdown pattern (Developers / Community / Company). Parent points at `/stablecoins` (the lead use case); sub-items are internal `<Link>` navigation.
- **Mobile** (`NavMenu2.tsx`): same entry, first in the accordion.

Gives the sales assets persistent, every-page discoverability heading into outreach, and it's extensible as more use cases land.

Built green locally with `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
