### PR TITLE
Hero copy: 'Keys no one else can extract'

### DIFF
--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -45,7 +45,7 @@ const LandingHero = () => {
           Sign on any chain, only by your rules.{' '}
           <br className="hidden md:inline" />
           <span className="text-lit-orange">
-            Keys no operator can extract. Not even us.
+            Keys no one else can extract. Not even us.
           </span>
         </h1>
         <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed">


### PR DESCRIPTION
Follow-up to #42 (already merged). Main landed the hero key claim as *'no operator can extract'*; this corrects it to the approved wording:

**Keys no one else can extract. Not even us.**

Accurate — an owner can export their own keys, so the claim is that no one *else* can (not Lit, not operators) — and it reads cleaner than 'no operator'. One-line copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)