### PR TITLE
Pricing card: 'less on annual plans'

### DIFF
--- a/src/components/LandingHowItWorks/LandingHowItWorks.tsx
+++ b/src/components/LandingHowItWorks/LandingHowItWorks.tsx
@@ -113,7 +113,7 @@ const LandingHowItWorks = () => {
             <div className="grid grid-cols-2 gap-4">
               <Stat k="Latency" v="Sub-second signing" />
               <Stat k="Auditability" v="Code hash on-chain" />
-              <Stat k="Pricing" v="$0.01/sec, less at scale" href={PRICING_DOCS} />
+              <Stat k="Pricing" v="$0.01/sec, less on annual plans" href={PRICING_DOCS} />
               <Stat k="Surface" v="Any HTTP, any chain" />
             </div>
           </div>


### PR DESCRIPTION
Follow-up to #42. Changes the pricing stat from '$0.01/sec, less at scale' (volume vibe) to **'$0.01/sec · annual discount'** — reflects the discount-for-annual-subscription model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)