### PR TITLE
Hero: 'Keys no one can extract. Not even us.'

### DIFF
--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -45,7 +45,7 @@ const LandingHero = () => {
           Sign on any chain, only by your rules.{' '}
           <br className="hidden md:inline" />
           <span className="text-lit-orange">
-            Keys no one else can extract. Not even us.
+            Keys no one can extract. Not even us.
           </span>
         </h1>
         <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed">


### PR DESCRIPTION
Reverts the hero key line from 'no one else' back to **'Keys no one can extract. Not even us.'** — the preferred wording. Defensible: 'extract' = the operator/unauthorized pull-out Lit guarantees is impossible (docs: *'nothing that touches key material ever leaves the enclave'*, *'no operator can see or extract them'*); owner-initiated *export* is a separate action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)