### PR TITLE
Add /rwa position paper (tokenized real-world assets)

### DIFF
--- a/src/app/rwa/_components/PaperLayout.tsx
+++ b/src/app/rwa/_components/PaperLayout.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useState } from 'react';
+import { HeaderMenu } from '@/components/Header/Header';
+import { NavMenu2 } from '@/components/NavMenu/NavMenu2';
+
+// Same chrome as the site Layout (header + slide-out nav) but without the global
+// newsletter Footer — the position paper ends with its own References and disclaimer.
+export default function PaperLayout({ children }: { children: React.ReactNode }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const toggleMenu = () => setMenuOpen((v) => !v);
+
+  return (
+    <>
+      <HeaderMenu menuOpen={menuOpen} toggleMenu={toggleMenu} />
+      <main className="relative h-full min-h-[100vh] w-full">{children}</main>
+      <NavMenu2 menuOpen={menuOpen} toggleMenu={toggleMenu} />
+    </>
+  );
+}

--- a/src/app/rwa/_components/WhitePaper.tsx
+++ b/src/app/rwa/_components/WhitePaper.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { Container } from '@mantine/core';
+import { IconArrowNarrowRight, IconExternalLink } from '@tabler/icons-react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { Button } from '@/components/ui/Button';
+import { SRC } from './citations';
+
+const DOCS_EXAMPLES = 'https://developer.litprotocol.com/lit-actions/examples';
+const DEPLOYMENT_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLScQ8dU09fbdRa6Al70rP9Bb-iX_CngnGl1U6_YFh7s0UyKgkQ/viewform';
+
+// Defined before the data tables below, which reference it (const is not hoisted — TDZ).
+const Fn = ({ n }: { n: number }) => (
+  <sup className="ml-px">
+    <a href={`#ref-${n}`} className="font-mono text-[0.6em] text-lit-orange transition-colors hover:text-gold-500">
+      [{n}]
+    </a>
+  </sup>
+);
+
+/* ---------------- structure ---------------- */
+
+const SECTIONS = [
+  { id: 'single-point', n: '1', title: 'The single point of failure' },
+  { id: 'problem', n: '2', title: 'Control by promise' },
+  { id: 'shift', n: '3', title: 'Verifiable control' },
+  { id: 'powers', n: '4', title: 'Privileged power, enforced at signing' },
+  { id: 'proof', n: '5', title: 'What an issuer can prove' },
+  { id: 'architecture', n: '6', title: 'The architecture' },
+  { id: 'scope', n: '7', title: 'Honest scope' },
+  { id: 'implementation', n: '8', title: 'Implementation' },
+  { id: 'references', n: '9', title: 'References' },
+];
+
+const REFERENCES: { n: number; text: ReactNode; href: string }[] = [
+  { n: 1, text: 'Halborn, “Explained: The Paxos PYUSD Incident (October 2025)” — on Oct. 15, 2025 a typo turned an intended $300M transfer into roughly $300 trillion in PYUSD, burned about 22 minutes later; per Halborn, supply was controlled by a single externally owned account with unlimited mint privileges and no multi-signature wallet or built-in controls. See also CNBC (Oct. 16, 2025).', href: SRC.pyusdHalborn },
+  { n: 2, text: 'BlockSec, “Drift Protocol Incident” — on Apr. 1, 2026 (UTC) attackers phished two of five signers on a 2-of-5, zero-timelock governance multisig and exploited Solana “durable nonces” to drain approximately $285.3 million.', href: SRC.drift },
+  { n: 3, text: 'CoinDesk, “Tether Accidentally Minted $5 Billion of Its Stablecoins, Then Deleted Them” (July 16, 2019) — a token-decimal error during a chain swap created $5B USDT, subsequently burned to the intended value.', href: SRC.tether },
+  { n: 4, text: 'PAID Network attack postmortem (attack Mar. 5, 2021; postmortem published Mar. 7, 2021) — a compromised deployer key with authority over the contract’s upgrade function let an attacker replace the token and mint at will.', href: SRC.paid },
+  { n: 5, text: 'The Block, “Court-ordered Circle freeze traps $12.6 million in Zama cUSDC contract” (May 2026) — pursuant to a temporary restraining order, Circle blacklisted a shared pooled “confidential USDC” contract (~12,606,386 USDC), locking every depositor including uninvolved users; a court lifted the freeze on June 1, 2026 as unwarranted.', href: SRC.zama },
+  { n: 6, text: 'ERC-3643 (T-REX) standard, EIP-3643 — Owner (ERC-173) and Agent roles hold mint, forced-transfer, and recovery powers; the standard recommends but does not require those roles to be a multisig or contract, permitting ordinary externally owned accounts.', href: SRC.erc3643 },
+  { n: 7, text: 'QuillAudits, “ERC-3643 Explained” — flags the centralization risk: “if these agent keys are compromised or misused, assets can be arbitrarily moved, frozen, or reassigned,” and that limiting agent roles via multisig or contract-based access control “is a necessity.”', href: SRC.erc3643Audit },
+  { n: 8, text: 'Securitize DSToken (securitize-io/dstoken) — exposes a role-gated seize(address,address,uint256,string) that forcibly transfers tokens to a designated issuer wallet, deployed behind an upgradeable OpenZeppelin ERC-1967 proxy whose implementation an administrator can replace.', href: SRC.dstoken },
+  { n: 9, text: 'SEC staff statement on tokenized securities (Jan. 28, 2026), Divisions of Corporation Finance, Investment Management, and Trading & Markets — federal securities laws apply regardless of whether a security is tokenized; the statement grants no relief and creates no new framework.', href: SRC.secTokenized },
+  { n: 10, text: 'Commissioner Hester M. Peirce, “Enchanting, but Not Magical: A Statement on the Tokenization of Securities” (July 9, 2025) — tokenization does not transform the nature of the underlying asset; tokenized securities remain securities subject to the federal securities laws.', href: SRC.peirce },
+  { n: 11, text: 'AICPA, “Updates Criteria for Stablecoin Reporting to Address Controls Over Stablecoin Operations” (Jan. 12, 2026) — a framework for controls over issuance, redemption, asset custody, and vendor management; the nearest published analog for controls over token operations.', href: SRC.aicpa },
+  { n: 12, text: 'GENIUS Act, Pub. L. No. 119-27 (2025), § 17 — amends the federal securities and commodities laws so that a payment stablecoin issued by a permitted issuer is not a “security” or “commodity”; the Act regulates payment stablecoins, not securities, so tokenized securities have no GENIUS-equivalent mandate.', href: SRC.geniusText },
+  { n: 13, text: 'Regulation (EU) 2023/1114 (MiCA), Art. 2 — does not apply to crypto-assets that qualify as financial instruments under MiFID II; tokenized securities remain under the existing EU financial-services regime, not MiCA.', href: SRC.mica },
+  { n: 14, text: 'Lit Protocol, “Introducing Lit Protocol v3 (Chipotle)” — TEE-based execution, on-chain key orchestration, and hardware attestation.', href: SRC.chipotle },
+  { n: 15, text: 'Lit Protocol developer documentation — on-chain permissions on Base and the On-Chain KMS: root-key release is gated by smart contracts on Base, with every configuration change a public, auditable transaction on Basescan.', href: SRC.onchainKms },
+  { n: 16, text: '“Proof of Cloud: Data Center Execution Assurance for Confidential VMs,” arXiv:2510.12469 — extends hardware attestation to prove an enclave runs in vetted infrastructure.', href: SRC.pocPaper },
+];
+
+const TABLE1: { ob: ReactNode; cap: ReactNode }[] = [
+  { ob: <>Mint<Fn n={1} /></>, cap: <>A supply cap and sanity-bound invariants live in code; no signature is produced if a mint would exceed the on-chain cap. The PYUSD ~$300-trillion class becomes impossible, not monitored.</> },
+  { ob: <>Burn / redeem</>, cap: 'Condition-gated and governance-bound; each burn is an attested record.' },
+  { ob: <>Freeze / block</>, cap: 'A sanctions and eligibility screen runs inside the enclave; the signature is withheld on a hit, and the block is itself an attested record — without publishing the holder or amount on-chain.' },
+  { ob: <>Seize</>, cap: 'Executes only on a verified, governance-bound lawful order; attested, with no discretionary operator path.' },
+  { ob: <>Reissue / recover</>, cap: 'Bound to verified loss or order conditions; attested; cannot be triggered outside policy.' },
+];
+
+const TABLE2: { who: string; claim: ReactNode }[] = [
+  { who: 'Securities regulator / examiner', claim: <>Privileged operations occur only within policy, across every chain the asset touches, with evidence of each action and each refusal — even though no statute yet mandates the mechanism.<Fn n={9} /></> },
+  { who: 'Internal audit & SOC 2', claim: <>Segregation of duties enforced cryptographically; a complete, tamper-evident trail; control effectiveness demonstrated continuously, not sampled — against COSO and SOC 2, with the AICPA’s 2026 controls-over-stablecoin-operations criteria as the nearest published analog.<Fn n={11} /></> },
+  { who: 'Board & risk committee', claim: 'No key-person or operator single point of failure; policy changeable only by governance; the PYUSD and Drift failure class is removed, not monitored.' },
+  { who: 'Counterparties, LPs & investors', claim: 'A non-custodial guarantee that is cryptographically verifiable, rather than asserted.' },
+];
+
+const FLOW = [
+  { n: '01', t: 'Authorize against the chain', s: 'The enclave reads the on-chain permission contracts: is the caller allowed, and is this policy bound to this key?' },
+  { n: '02', t: 'Fetch the immutable policy', s: 'It loads the exact policy by content identifier — content-addressed, so the code cannot have been substituted.' },
+  { n: '03', t: 'Enforce', s: 'The policy runs in a sandbox: sanctions and eligibility screen, supply cap, lawful-order check, limits. If any check fails, no signature is produced.' },
+  { n: '04', t: 'Sign, without exposing the key', s: 'Only on success does the enclave use the key. The key never leaves the hardware; the decision — and any refusal — is attested.' },
+];
+
+/* ---------------- primitives ---------------- */
+
+const P = ({ children }: { children: ReactNode }) => (
+  <p className="mt-4 text-[1.02rem] leading-[1.72] text-white/70">{children}</p>
+);
+
+const Lead = ({ children }: { children: ReactNode }) => <strong className="font-medium text-white">{children}</strong>;
+
+function SectionHead({ n, id, title }: { n: string; id: string; title: string }) {
+  return (
+    <div className="mb-2 flex items-baseline gap-3">
+      <span className="font-mono text-sm text-lit-orange-700">{n}</span>
+      <h2 className="text-[clamp(1.5rem,2.6vw,2rem)] font-medium leading-tight tracking-tight" id={id}>
+        {title}
+      </h2>
+    </div>
+  );
+}
+
+/* ---------------- document ---------------- */
+
+export default function WhitePaper() {
+  const [active, setActive] = useState<string>('single-point');
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setActive((e.target as HTMLElement).id);
+        });
+      },
+      { rootMargin: '-20% 0px -70% 0px' }
+    );
+    SECTIONS.forEach((s) => {
+      const el = document.getElementById(`sec-${s.id}`);
+      if (el) obs.observe(el);
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div className="bg-coal-950 text-white">
+      {/* MASTHEAD */}
+      <header className="relative overflow-hidden border-b border-white/10">
+        <div className="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[min(1000px,140vw)] -translate-x-1/2 -translate-y-1/3 blur-[10px] bg-[radial-gradient(ellipse_at_center,_oklch(53.51%_0.163_39.51/0.20)_0%,_transparent_64%)]" />
+        <Container size="lg" className="relative !pt-20 !pb-16 md:!pt-28">
+          <div className="font-mono text-xs uppercase tracking-[0.28em] text-lit-orange">Position paper</div>
+          <h1 className="mt-5 max-w-[18ch] text-[clamp(2.5rem,6.5vw,5rem)] font-medium leading-[1.0] tracking-tight">
+            Provable Control
+          </h1>
+          <p className="mt-5 max-w-[46ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
+            Code-enforced authority for the privileged keys behind tokenized real-world assets.
+          </p>
+          <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/55">
+            <span>Mint · burn · freeze · seize — those keys are the single point of failure.</span>
+          </div>
+          <div className="mt-9 flex flex-wrap gap-3">
+            <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+              Book a deployment review
+            </Button>
+            <Button variant="outline" href={DOCS_EXAMPLES} target="_blank" rel="noopener noreferrer">
+              See the Lit Actions examples
+            </Button>
+          </div>
+        </Container>
+      </header>
+
+      <Container size="lg" className="!py-16 md:!py-20">
+        {/* ABSTRACT */}
+        <div className="mx-auto max-w-[44rem] rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
+          <div className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-lit-orange">Abstract</div>
+          <p className="text-[1.05rem] leading-[1.75] text-white/80">
+            Tokenized real-world assets — treasuries, funds, private credit, securities — are controlled by privileged keys: the authority to mint, burn, freeze, seize, and reissue. Today that authority sits in an administrative account, a multisig, or a custodial operator’s mutable policy — a single point of failure that a person can misuse, be coerced into using, be subpoenaed against, or trigger by accident, and whose failures surface only after they settle. The roughly $300 trillion that Paxos accidentally minted in October 2025,<Fn n={1} /> and the ~$285 million drained from Drift through a phished multisig in April 2026,<Fn n={2} /> are not edge cases; they are the failure mode. Unlike payment stablecoins, no statute mandates a remedy for tokenized securities<Fn n={12} /><Fn n={13} /> — the forcing function is risk, not a deadline. This paper sets out a control architecture in which privileged-key authority is generated and used only inside sealed hardware, bound to immutable on-chain policy, and attested on every action and every refusal. The authority cannot be exercised outside its policy — by an operator, an intruder, or an error — and every use, and every refusal, leaves a verifiable record. Control becomes something an issuer or transfer agent can <Lead>prove</Lead> rather than promise.
+          </p>
+        </div>
+
+        {/* GRID: TOC + body */}
+        <div className="wp-grid mt-16 lg:grid lg:grid-cols-[200px_minmax(0,44rem)] lg:justify-center lg:gap-16">
+          {/* TOC */}
+          <nav className="mb-10 hidden lg:block">
+            <div className="sticky top-24">
+              <div className="mb-4 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-white/40">Contents</div>
+              <ul className="space-y-2.5">
+                {SECTIONS.map((s) => (
+                  <li key={s.id}>
+                    <a
+                      href={`#sec-${s.id}`}
+                      className={`flex gap-2.5 text-sm transition-colors ${active === s.id ? 'text-lit-orange' : 'text-white/45 hover:text-white/80'}`}
+                    >
+                      <span className="font-mono text-xs opacity-60">{s.n}</span>
+                      {s.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </nav>
+
+          {/* BODY */}
+          <article className="wp-doc max-w-[44rem]">
+            {/* 1 */}
+            <section id="sec-single-point" className="scroll-mt-24">
+              <SectionHead n="1" id="single-point" title="The single point of failure" />
+              <P>
+                Every tokenized asset depends on privileged keys. Someone must be able to mint new units against new backing, burn on redemption, freeze a sanctioned holder, and — under a lawful order — seize or reissue. Those powers are legitimate and necessary. The open question is who, or what, holds them, and what constrains their use.
+              </P>
+              <P>
+                Today the answer is an ordinary administrative key, and the failures are on the record. On October 15, 2025, Paxos — the regulated issuer of PayPal’s PYUSD — accidentally minted roughly $300 trillion in PYUSD when a typo turned an intended $300 million transfer into $300 trillion; the excess was burned about 22 minutes later. According to security firm Halborn, PYUSD’s supply was controlled by a single externally owned account with unlimited mint privileges, without a multi-signature wallet or built-in controls.<Fn n={1} />
+              </P>
+              <P>
+                It is not an isolated error. In April 2026, attackers phished two of five signers on Drift’s governance multisig — a 2-of-5, zero-timelock configuration — and exploited Solana “durable nonces” to drain roughly $285 million.<Fn n={2} /> In 2019, Tether accidentally minted $5 billion in USDT through a token-decimal error before reversing it.<Fn n={3} /> In March 2021, a compromised deployer key with authority over PAID Network’s contract upgrade let an attacker replace the token and mint at will.<Fn n={4} /> Different assets, different mechanisms, one root cause: a privileged key that a single party holds, and that the contract simply trusts.
+              </P>
+              <P>
+                Payment stablecoins now have a dated mandate to address this — the GENIUS Act. Tokenized securities do not: GENIUS regulates payment stablecoins, not securities,<Fn n={12} /> and the EU’s MiCA excludes financial instruments.<Fn n={13} /> No statute prescribes the mechanism. But securities laws apply regardless of an asset’s format — the SEC’s staff has been explicit that tokenization changes the plumbing, not the regulatory perimeter<Fn n={9} /> — and the operational risk above is realized, repeatedly. The forcing function is risk, and the standard a board and an auditor already apply.
+              </P>
+            </section>
+
+            {/* 2 */}
+            <section id="sec-problem" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="2" id="problem" title="Control by promise" />
+              <P>
+                Most tokenized-asset programs meet a control requirement the way the industry always has: a privileged role on the token contract, held by an issuer, transfer agent, or custodian, plus a written policy describing how it will be used. The asset’s holders, the issuer’s board, and any examiner are then asked to trust that the key is held securely, used only as the policy says, and that misuse would be caught — each verified after the fact, by sampling logs.
+              </P>
+              <P>
+                The dominant tokenization standard builds this in. ERC-3643 (T-REX) vests privileged Owner and Agent roles with the power to mint, force transfers, and recover wallets; the standard recommends, but does not require, that those roles be decentralized — they may be ordinary accounts or multisigs the contract trusts.<Fn n={6} /> Its own reviewers flag the risk: if the agent keys “are compromised or misused, assets can be arbitrarily moved, frozen, or reassigned.”<Fn n={7} /> Securitize’s widely deployed DSToken exposes a discretionary, role-gated <code className="rounded bg-white/[0.06] px-1 py-0.5 font-mono text-[0.85em]">seize()</code> — a forced transfer to a designated issuer wallet — behind an upgradeable proxy whose implementation an administrator can replace.<Fn n={8} /> Custodial policy engines add a further layer of trust: they enforce rules a workspace owner can edit, and you trust the operator that the enclave runs the code it claims.
+              </P>
+              <P>This model is <Lead>promissory and post-hoc</Lead>, and weak by the standard of any serious control framework:</P>
+              <ul className="mt-4 space-y-3">
+                {[
+                  ['It depends on a person.', 'A key one administrator can use is a key one administrator can misuse, be compelled to use, or use by mistake — and a single point of compromise.'],
+                  ['It does not travel.', 'A control on one chain does not reach the same asset bridged to another.'],
+                  ['It does not reach far enough.', 'A contract-level role cannot stop a self-custodied wallet, a smart contract, or an autonomous agent from initiating a non-compliant transfer.'],
+                  ['It can fail onto innocents.', <>In May 2026, a court-ordered freeze forced Circle to blacklist a shared pooled USDC contract, locking roughly $12.6 million belonging to every depositor — including users with no connection to the dispute; a court reversed it days later as unwarranted.<Fn n={5} /> The operator complied correctly. Innocent parties still lost access.</>],
+                ].map(([h, b], i) => (
+                  <li key={i} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/70">
+                    <span className="absolute left-0 top-[0.6rem] h-1.5 w-1.5 rounded-full bg-lit-orange-700" />
+                    <Lead>{h}</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>
+                A securities regulator and an internal auditor share the same concern. A control a single party can circumvent, that produces no tamper-evident record, and whose effectiveness can only be sampled is weak under COSO, SOC 2, and SOX alike.
+              </P>
+            </section>
+
+            {/* 3 */}
+            <section id="sec-shift" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="3" id="shift" title="Verifiable control" />
+              <P>The alternative is to verify the system rather than trust the holder. Four properties make a privileged key impossible to exercise outside its policy:</P>
+              <ul className="mt-4 space-y-3">
+                {[
+                  ['Blind.', <>The privileged signing key is generated and used only inside a sealed trusted execution environment (TEE). No operator, host, or vendor — Lit included — can see or extract it.<Fn n={14} /><Fn n={15} /></>],
+                  ['Bound.', <>The key’s authority is not an administrative setting but on-chain state on Base: it signs only what an immutable, content-addressed policy permits. Changing what it can do is an on-chain governance action, not an admin switch.<Fn n={15} /></>],
+                  ['Verifiable.', <>Every action the key takes, and every transfer it refuses, is a hardware-attested record — provable to a regulator or auditor, asserted by no single operator.<Fn n={16} /></>],
+                  ['Confidential.', 'The same enclave screens the holder and amount in the clear only to enforce policy; investor identities, balances, and the counterparty graph never touch the public chain. An issuer screens against sanctions and eligibility without publishing its book to the world.'],
+                ].map(([h, b], i) => (
+                  <li key={i} className="relative pl-6 text-[1.02rem] leading-[1.7] text-white/80">
+                    <span className="absolute left-0 top-[0.55rem] font-mono text-lit-orange">◆</span>
+                    <Lead>{h}</Lead> {b}
+                  </li>
+                ))}
+              </ul>
+              <P>
+                Together they relocate the privileged key out of human hands: no administrator, intruder, or error can sign around the control, and the screen runs without putting investor activity on-chain. That is what <Lead>impossible to misuse outside its policy</Lead> means here; §6 makes it precise.
+              </P>
+            </section>
+
+            {/* 4 */}
+            <section id="sec-powers" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="4" id="powers" title="Privileged power, enforced at signing" />
+              <P>Each privileged power becomes a capability enforced at the moment of signing, rather than a discretion asserted in a policy.</P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-1/4 p-4 font-normal">Privileged power</th>
+                      <th className="p-4 font-normal">Enforced at signing</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TABLE1.map((r, i) => (
+                      <tr key={i} className="border-t border-white/10 align-top">
+                        <td className="whitespace-nowrap p-4 text-[0.95rem] font-medium text-white">{r.ob}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.cap}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Table 1 — Privileged powers mapped to controls enforced at signing.</figcaption>
+            </section>
+
+            {/* 5 */}
+            <section id="sec-proof" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="5" id="proof" title="What an issuer can prove" />
+              <P>One architecture, demonstrable to four different audiences.</P>
+              <figure className="mt-6 overflow-x-auto rounded-xl border border-white/10">
+                <table className="w-full border-collapse text-left align-top">
+                  <thead>
+                    <tr className="bg-white/[0.03] font-mono text-[0.68rem] uppercase tracking-[0.12em] text-white/40">
+                      <th className="w-1/3 p-4 font-normal">Audience</th>
+                      <th className="p-4 font-normal">What an issuer or transfer agent can prove</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TABLE2.map((r, i) => (
+                      <tr key={i} className="border-t border-white/10 align-top">
+                        <td className="p-4 text-[0.95rem] font-medium text-white">{r.who}</td>
+                        <td className="p-4 text-[0.92rem] leading-relaxed text-white/65">{r.claim}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Table 2 — Guarantees demonstrable to each audience.</figcaption>
+            </section>
+
+            {/* 6 */}
+            <section id="sec-architecture" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="6" id="architecture" title="The architecture" />
+              <P>Three layers implement the properties. Each is independently inspectable.</P>
+              <P>
+                <Lead>Blind execution.</Lead> Lit Actions — the policies — run inside trusted execution environments, where the signing key is derived and used. The network connection terminates inside the enclave, so there is no point at which key material is exposed; nothing that touches it leaves.<Fn n={14} /><Fn n={15} />
+              </P>
+              <P>
+                <Lead>Bound to the chain.</Lead> A key’s authority is on-chain state on Base: permission contracts bind each key to the exact, content-addressed policies it may run. Changing what a key can do means changing on-chain state under the issuer’s own governance — recorded, and auditable on Basescan — not flipping an administrative switch.<Fn n={15} />
+              </P>
+              <P>
+                <Lead>Verifiable hardware.</Lead> Each enclave emits a hardware attestation: a signed, deterministic measurement of the exact code running inside. The Proof of Cloud approach extends that attestation to prove the machine runs in vetted infrastructure rather than on an attacker’s bench — closing the physical side-channel gap.<Fn n={16} />
+              </P>
+              <figure className="mt-7 rounded-2xl border border-dashed border-lit-orange/30 bg-[radial-gradient(120%_120%_at_50%_0,_oklch(53.51%_0.163_39.51/0.06),_transparent_60%)] px-5 pb-6 pt-9">
+                <span className="-mt-12 mb-1 block font-mono text-[0.7rem] tracking-wide text-lit-orange">Sealed enclave · operators are blind</span>
+                <div className="mt-3 grid gap-2.5">
+                  {FLOW.map((f) => (
+                    <div key={f.n} className="flex items-start gap-4 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3">
+                      <span className="w-6 shrink-0 pt-0.5 font-mono text-xs font-semibold text-lit-orange">{f.n}</span>
+                      <div>
+                        <b className="block text-[0.95rem] font-medium">{f.t}</b>
+                        <span className="text-sm text-white/55">{f.s}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </figure>
+              <figcaption className="mt-3 font-mono text-[0.72rem] text-white/35">Figure 1 — The lifecycle of a single privileged signing request inside the enclave.</figcaption>
+              <P>
+                <Lead>A note on trust.</Lead> No system eliminates trust; it relocates trust to assumptions that can be independently verified. Here those are the silicon vendor’s hardware root of trust and the on-chain governance that sets policy — both externally attestable, the former hardened by Proof of Cloud, the latter auditable on Basescan.<Fn n={15} /> There is no trusted operator.
+              </P>
+            </section>
+
+            {/* 7 */}
+            <section id="sec-scope" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="7" id="scope" title="Honest scope" />
+              <P>
+                The defensible claim is a pair of properties in combination, and it is worth stating plainly what this does and does not do. The moat is privileged-key authority <Lead>bound to immutable, content-addressed policy</Lead> — not a mutable configuration — and <Lead>externally provable</Lead> through attestation of every action and every refusal, with no operator to trust. Policy-in-a-TEE, non-custodial signing, and hardware attestation each exist elsewhere; the combination — immutable on-chain policy plus decentralized, externally verifiable attestation — is what removes the privileged-key single point of failure rather than relocating it.
+              </P>
+              <P>
+                What this is <Lead>not</Lead>: a regulatory mandate. No statute requires this mechanism for tokenized securities. Securities laws apply regardless of an asset’s format — a tokenized security is still a security, and tokenization changes the plumbing, not the regulatory perimeter<Fn n={9} /><Fn n={10} /> — but the driver here is operational risk and internal-control rigor, not a deadline. This architecture is a control; it is not legal advice and creates no legal obligation.
+              </P>
+            </section>
+
+            {/* 8 */}
+            <section id="sec-implementation" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="8" id="implementation" title="Implementation" />
+              <P>
+                Demonstrable capability is reached fastest by starting narrow. A reference implementation can enforce sanctions-screened, supply-capped minting plus a governance-bound seize and freeze on a single asset and a single chain, prove it end-to-end, then extend across the other chains the asset touches. The architecture is cross-chain by design; starting on one chain proves the control, not a retreat from it. The goal is a control an examiner and an auditor can verify — not a finished platform.
+              </P>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Button href={DEPLOYMENT_FORM} target="_blank" rel="noopener noreferrer" rightIcon={<IconArrowNarrowRight stroke={2} />}>
+                  Book a deployment review
+                </Button>
+                <Button variant="outline" href={DOCS_EXAMPLES} target="_blank" rel="noopener noreferrer">
+                  See the Lit Actions examples
+                </Button>
+              </div>
+            </section>
+
+            {/* 9 */}
+            <section id="sec-references" className="mt-14 scroll-mt-24 border-t border-white/10 pt-14">
+              <SectionHead n="9" id="references" title="References" />
+              <ol className="mt-4 space-y-3">
+                {REFERENCES.map((r) => (
+                  <li key={r.n} id={`ref-${r.n}`} className="scroll-mt-24 flex gap-3 text-[0.9rem] leading-relaxed text-white/60">
+                    <span className="font-mono text-xs text-lit-orange-700">[{r.n}]</span>
+                    <span>
+                      {r.text}{' '}
+                      <a href={r.href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 whitespace-nowrap text-lit-orange transition-colors hover:text-gold-500">
+                        link <IconExternalLink size={11} stroke={2} className="opacity-70" />
+                      </a>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              <p className="mt-10 border-t border-white/10 pt-5 font-mono text-[0.7rem] leading-relaxed text-white/30">
+                Informational only — not legal advice. Tokenized securities remain subject to existing securities laws regardless of format; see the SEC staff statement on tokenized securities (Jan. 28, 2026). No statement here creates a legal obligation or describes a regulatory mandate. Incident figures are drawn from the cited third-party reports and reflect those sources. Architecture described is current to Lit Protocol v3 and subject to change. Consult qualified counsel before relying on any statement here.
+              </p>
+            </section>
+          </article>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/app/rwa/_components/WhitePaper.tsx
+++ b/src/app/rwa/_components/WhitePaper.tsx
@@ -138,6 +138,11 @@ export default function WhitePaper() {
               See the Lit Actions examples
             </Button>
           </div>
+          <div className="mt-5">
+            <a href="/stablecoins" className="font-mono text-xs text-white/55 underline-offset-4 transition hover:text-gold-500 hover:underline">
+              Issuing a payment stablecoin under the GENIUS Act? See /stablecoins →
+            </a>
+          </div>
         </Container>
       </header>
 

--- a/src/app/rwa/_components/citations.ts
+++ b/src/app/rwa/_components/citations.ts
@@ -1,0 +1,55 @@
+// Authoritative source links for the /rwa position paper. Keep citations exact.
+// Every figure/date below was independently fact-checked before publication.
+
+export const SRC = {
+  // --- Incidents (the realized risk) ---
+  // PYUSD ~$300T accidental mint — Oct 15, 2025. Mechanism attributed to Halborn.
+  pyusdHalborn:
+    'https://www.halborn.com/blog/post/explained-the-paxos-pyusd-incident-october-2025',
+  pyusdCnbc:
+    'https://www.cnbc.com/2025/10/16/paypals-crypto-partner-mints-300-trillion-stablecoins-in-technical-error.html',
+  // Drift ~$285M — Apr 1, 2026 (UTC). 2-of-5 multisig phished; durable-nonce exploit.
+  drift:
+    'https://blocksec.com/blog/drift-protocol-incident-multisig-governance-compromise-via-durable-nonce-exploitation',
+  // Tether $5B over-mint — July 2019 (decimal error), reversed.
+  tether:
+    'https://www.coindesk.com/markets/2019/07/16/tether-accidentally-minted-5-billion-of-its-stablecoins-then-deleted-them',
+  // PAID Network — attack Mar 5, 2021; compromised deployer key with upgrade authority.
+  paid:
+    'https://paidnetwork.medium.com/paid-network-attack-postmortem-march-7-2021-9e4c0fef0e07',
+  // Zama/Circle court-ordered freeze of pooled cUSDC (~$12.6M) — May 30, 2026; reversed June 1, 2026.
+  zama:
+    'https://www.theblock.co/post/403091/court-ordered-circle-freeze-traps-12-6-million-in-zama-cusdc-contract-amid-overnight-finance-suit',
+
+  // --- Standards & contracts (control by promise) ---
+  erc3643: 'https://eips.ethereum.org/EIPS/eip-3643',
+  erc3643Audit: 'https://www.quillaudits.com/blog/rwa/erc-3643-explained',
+  dstoken: 'https://github.com/securitize-io/dstoken',
+
+  // --- Regulatory context (no dated mandate for securities) ---
+  // SEC staff statement on tokenized securities (Jan 28, 2026) — Corp Fin, Inv. Mgmt, Trading & Markets.
+  secTokenized:
+    'https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826-statement-tokenized-securities',
+  // Commissioner Peirce, "Enchanting, but Not Magical" (July 9, 2025).
+  peirce:
+    'https://www.sec.gov/newsroom/speeches-statements/peirce-statement-tokenized-securities-070925',
+  // AICPA — controls over stablecoin operations (Jan 12, 2026).
+  aicpa:
+    'https://www.aicpa-cima.com/news/article/aicpa-updates-criteria-for-stablecoin-reporting-to-address-controls-over',
+  // GENIUS Act §17 — payment stablecoins are not securities (so securities have no GENIUS mandate).
+  geniusText:
+    'https://www.congress.gov/bill/119th-congress/senate-bill/1582/text',
+  // MiCA Art. 2 — excludes financial instruments (tokenized securities sit outside MiCA).
+  mica: 'https://eur-lex.europa.eu/eli/reg/2023/1114/oj',
+
+  // --- Lit architecture ---
+  chipotle: 'https://spark.litprotocol.com/introducing-lit-protocol-v3-chipotle/',
+  litDocs: 'https://developer.litprotocol.com',
+  // On-Chain KMS — Base smart contracts gate key release; audit trail on Basescan.
+  onchainKms:
+    'https://developer.litprotocol.com/architecture/verification/onchain-kms',
+  pocSite: 'https://proofofcloud.org/',
+  pocPaper: 'https://arxiv.org/abs/2510.12469',
+};
+
+export type SourceItem = { label: string; note?: string; href: string };

--- a/src/app/rwa/opengraph-image.tsx
+++ b/src/app/rwa/opengraph-image.tsx
@@ -1,0 +1,120 @@
+import { ImageResponse } from 'next/server';
+
+export const runtime = 'edge';
+export const alt =
+  'Provable Control — a Lit Protocol position paper on code-enforced authority for the privileged keys behind tokenized real-world assets.';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Bespoke Open Graph / Twitter card for /rwa (Next wires it automatically).
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '84px',
+          background: '#0b0806',
+          color: 'white',
+          position: 'relative',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: -180,
+            right: -160,
+            width: 680,
+            height: 680,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,91,41,0.22) 0%, transparent 62%)',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: -220,
+            left: -180,
+            width: 620,
+            height: 620,
+            display: 'flex',
+            background:
+              'radial-gradient(circle, rgba(255,206,94,0.12) 0%, transparent 62%)',
+          }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            fontSize: 24,
+            letterSpacing: '0.28em',
+            color: '#ff8a3d',
+            marginBottom: 30,
+            fontFamily: 'monospace',
+          }}
+        >
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: 999,
+              background: '#ff5b29',
+              display: 'flex',
+            }}
+          />
+          LIT PROTOCOL · POSITION PAPER
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 116,
+            fontWeight: 600,
+            letterSpacing: '-0.03em',
+            lineHeight: 1,
+          }}
+        >
+          Provable Control
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 34,
+            color: 'rgba(246,237,226,0.72)',
+            marginTop: 28,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          Code-enforced authority for the privileged keys behind tokenized real-world assets.
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginTop: 60,
+            color: 'rgba(255,255,255,0.5)',
+            fontSize: 24,
+            fontFamily: 'monospace',
+            letterSpacing: '0.12em',
+          }}
+        >
+          <span style={{ display: 'flex' }}>litprotocol.com/rwa</span>
+          <span style={{ display: 'flex' }}>MINT · BURN · FREEZE · SEIZE</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/rwa/page.tsx
+++ b/src/app/rwa/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import PaperLayout from './_components/PaperLayout';
+import WhitePaper from './_components/WhitePaper';
+
+const URL = 'https://litprotocol.com/rwa';
+const DESCRIPTION =
+  'Tokenized real-world assets are controlled by privileged keys — mint, burn, freeze, seize. How issuers and transfer agents make that authority impossible to misuse outside policy, and provable to a regulator or auditor.';
+
+export const metadata: Metadata = {
+  title: 'Provable Control: Privileged Keys for Tokenized RWAs | Lit Protocol',
+  description: DESCRIPTION,
+  alternates: { canonical: '/rwa' },
+  openGraph: {
+    type: 'article',
+    title: 'Provable Control — Code-Enforced Authority for Tokenized RWAs',
+    description: DESCRIPTION,
+    url: URL,
+    siteName: 'Lit Protocol',
+    publishedTime: '2026-06-09T00:00:00.000Z',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Provable Control — Lit Protocol',
+    description: DESCRIPTION,
+    creator: '@LitProtocol',
+  },
+  robots: { index: true, follow: true },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Provable Control',
+  alternativeHeadline:
+    'Code-enforced authority for the privileged keys behind tokenized real-world assets',
+  description: DESCRIPTION,
+  inLanguage: 'en',
+  datePublished: '2026-06-09',
+  dateModified: '2026-06-09',
+  author: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    url: 'https://litprotocol.com',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Lit Protocol',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://litprotocol.com/lit-logo.png',
+    },
+  },
+  mainEntityOfPage: URL,
+  image: 'https://litprotocol.com/api/og',
+  about: [
+    'real-world assets',
+    'tokenized securities',
+    'privileged key management',
+    'transfer agent controls',
+  ],
+};
+
+export default function RwaPage() {
+  return (
+    <PaperLayout>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <WhitePaper />
+    </PaperLayout>
+  );
+}

--- a/src/app/stablecoins/_components/WhitePaper.tsx
+++ b/src/app/stablecoins/_components/WhitePaper.tsx
@@ -119,7 +119,7 @@ export default function WhitePaper() {
             Verifiable Compliance
           </h1>
           <p className="mt-5 max-w-[46ch] text-[clamp(1.1rem,2vw,1.4rem)] leading-snug text-white/70">
-            Code-enforced control for regulated stablecoins and tokenized assets.
+            Code-enforced control for regulated stablecoins.
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs text-white/40">
             <span className="text-white/60">
@@ -133,6 +133,11 @@ export default function WhitePaper() {
             <Button variant="outline" href={DOCS_EXAMPLES} target="_blank" rel="noopener noreferrer">
               See the Lit Actions examples
             </Button>
+          </div>
+          <div className="mt-5">
+            <a href="/rwa" className="font-mono text-xs text-white/55 underline-offset-4 transition hover:text-gold-500 hover:underline">
+              Tokenizing securities, funds, or other real-world assets? See /rwa →
+            </a>
           </div>
         </Container>
       </header>

--- a/src/app/stablecoins/opengraph-image.tsx
+++ b/src/app/stablecoins/opengraph-image.tsx
@@ -95,7 +95,7 @@ export default function Image() {
             lineHeight: 1.3,
           }}
         >
-          Code-enforced control for regulated stablecoins and tokenized assets.
+          Code-enforced control for regulated stablecoins.
         </div>
 
         <div

--- a/src/app/stablecoins/opengraph-image.tsx
+++ b/src/app/stablecoins/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from 'next/server';
 
 export const runtime = 'edge';
 export const alt =
-  'Verifiable Compliance — a Lit Protocol position paper on code-enforced control for regulated stablecoins and tokenized assets.';
+  'Verifiable Compliance — a Lit Protocol position paper on code-enforced control for regulated stablecoins.';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 

--- a/src/app/stablecoins/page.tsx
+++ b/src/app/stablecoins/page.tsx
@@ -54,7 +54,7 @@ const jsonLd = {
   about: [
     'GENIUS Act',
     'stablecoin compliance',
-    'tokenized assets',
+    'payment stablecoins',
     'sanctions screening',
   ],
 };

--- a/src/app/stablecoins/page.tsx
+++ b/src/app/stablecoins/page.tsx
@@ -4,7 +4,7 @@ import WhitePaper from './_components/WhitePaper';
 
 const URL = 'https://litprotocol.com/stablecoins';
 const DESCRIPTION =
-  'The GENIUS Act takes effect Jan 18, 2027. How stablecoin and tokenized-asset issuers enforce block, freeze, and seize controls in code — and prove it.';
+  'The GENIUS Act takes effect Jan 18, 2027. How stablecoin issuers enforce block, freeze, and seize controls in code — and prove it.';
 
 export const metadata: Metadata = {
   title: 'Verifiable Compliance: Stablecoins & the GENIUS Act | Lit Protocol',
@@ -31,8 +31,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
   headline: 'Verifiable Compliance',
-  alternativeHeadline:
-    'Code-enforced control for regulated stablecoins and tokenized assets',
+  alternativeHeadline: 'Code-enforced control for regulated stablecoins',
   description: DESCRIPTION,
   inLanguage: 'en',
   datePublished: '2026-06-01',

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -107,6 +107,9 @@ const Footer = () => {
               <a href="/solvers" className={styles.footer__link}>
                 Solvers
               </a>
+              <a href="/rwa" className={styles.footer__link}>
+                RWAs
+              </a>
             </div>
             <div className="flex flex-col gap-3">
               <h6 className={styles.footer__category}>Social</h6>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -35,6 +35,7 @@ const links: LinkItem[] = [
     links: [
       { link: '/stablecoins', label: 'Stablecoins', external: false },
       { link: '/solvers', label: 'Solvers', external: false },
+      { link: '/rwa', label: 'RWAs', external: false },
     ],
   },
   {

--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -5,6 +5,9 @@ import { Button } from '../ui/Button';
 import { IconArrowNarrowRight, IconBrandGithub } from '@tabler/icons-react';
 import { CONTACT_FORM, QUICKSTART_LINK, GITHUB_LINK } from '@/utils/constants';
 
+const ONCHAIN_KMS =
+  'https://developer.litprotocol.com/architecture/verification/onchain-kms';
+
 const Pillar = ({ label, sub }: { label: string; sub: string }) => (
   <div className="border border-white/10 rounded-xl p-5 bg-white/[0.02] text-left">
     <div className="font-mono text-xs uppercase tracking-[0.2em] text-white/55">
@@ -78,14 +81,23 @@ const LandingHero = () => {
           <span className="text-white/20">·</span>
           <Metric value="$135M+" label="volume" />
         </div>
-        <div className="mt-4">
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-mono text-xs uppercase tracking-[0.16em] text-white/55">
           <a
             href={GITHUB_LINK}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-white/55 transition hover:text-gold-500"
+            className="inline-flex items-center gap-1.5 transition hover:text-gold-500"
           >
-            <IconBrandGithub size={15} stroke={1.8} /> Open source
+            <IconBrandGithub size={14} stroke={1.8} /> Open source
+          </a>
+          <span className="text-white/25">·</span>
+          <a
+            href={ONCHAIN_KMS}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition hover:text-gold-500"
+          >
+            Cryptographically verifiable
           </a>
         </div>
 

--- a/src/components/NavMenu/NavMenu2.tsx
+++ b/src/components/NavMenu/NavMenu2.tsx
@@ -26,6 +26,7 @@ const links: LinkItem[] = [
     links: [
       { link: '/stablecoins', label: 'Stablecoins', external: false },
       { link: '/solvers', label: 'Solvers', external: false },
+      { link: '/rwa', label: 'RWAs', external: false },
     ],
   },
   {

--- a/src/components/UseCases/UseCases.tsx
+++ b/src/components/UseCases/UseCases.tsx
@@ -17,6 +17,12 @@ const USE_CASES = [
     v: 'A policy gate in a TEE that signs only the inventory moves your rules allow.',
     href: '/solvers',
   },
+  {
+    tag: 'RWAs',
+    k: 'Control for tokenized real-world assets',
+    v: 'Mint, burn, freeze and seize, bound to immutable policy and provable to an auditor.',
+    href: '/rwa',
+  },
 ];
 
 const UseCases = () => (
@@ -30,7 +36,7 @@ const UseCases = () => (
           Where this matters most.
         </h2>
       </div>
-      <div className="grid md:grid-cols-2 gap-4 max-w-5xl mx-auto">
+      <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4 max-w-5xl mx-auto">
         {USE_CASES.map((d) => (
           <Link
             key={d.href}


### PR DESCRIPTION
Adds the **/rwa** position paper for tokenized real-world assets, scopes **/stablecoins** to its real subject, cross-links the two, and adds an open-source/verifiable credibility line to the homepage hero. Intended to land together.

**Preview:** https://litprotocol-com-v2-git-rwa-position-page-lit-protocol.vercel.app/rwa

### 1. New `/rwa` position paper
Modeled on `/stablecoins` but **anchored on operational risk, not a deadline** (tokenized securities have no GENIUS-equivalent mandate; MiCA excludes financial instruments). Thesis: privileged keys — mint, burn, freeze, seize, reissue — are the single point of failure; Lit binds that authority to immutable on-chain policy, runs it only in sealed TEEs, and attests every action *and every refusal*. Structure mirrors /stablecoins (masthead → abstract → sticky TOC → numbered sections → power→control + audience tables → architecture + lifecycle figure → references), no Countdown, plus an added **"Honest scope"** section.

**Every proof point independently fact-checked before writing:** PYUSD ~$300T (Oct 15 2025; mechanism attributed to Halborn), Drift ~$285M (Apr 2026), Tether $5B (2019), PAID (2021), Zama/Circle court-ordered freeze (~$12.6M, **reversed June 1 2026** — disclosed). Regulatory framing verified: SEC three-division statement (1/28/26), Peirce (7/9/25), AICPA stablecoin-ops criteria (1/12/26), GENIUS §17, MiCA Art. 2.

### 2. Scope `/stablecoins` to payment stablecoins
Now that `/rwa` owns the broad tokenized-asset story, `/stablecoins` is tightened to payment stablecoins + the GENIUS Act (subtitle, meta description, OG card + alt, structured-data dropped "and tokenized assets").

### 3. Cross-links
Bidirectional: `/stablecoins → /rwa` (securities/funds) and `/rwa → /stablecoins` (payment stablecoins), so the papers read as a deliberate pair.

### 4. Homepage
- Use Cases: third card (Stablecoins · Solvers · **RWAs**), 3-up grid; plus footer and both nav dropdowns.
- Hero: the open-source link becomes **"Open source · Cryptographically verifiable"** — two clickable proofs (GitHub + the On-Chain KMS verify page).

Built green. Desktop + the new page/links verified via headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
