### PR TITLE
Homepage hero: lead with verbs + non-custodial framing

### DIFF
--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -53,8 +53,8 @@ const LandingHero = () => {
         </h1>
         <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed">
           Your code runs in secure hardware that holds the keys and signs only
-          when your rules pass. No servers to run. Keys no one can extract,
-          not even us.
+          when your rules pass. Non-custodial, with no servers to run. Keys no
+          one can extract. Not even us.
         </p>
         <div className="mt-9 flex gap-3 justify-center flex-wrap">
           <Button

--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -45,15 +45,16 @@ const LandingHero = () => {
       </div>
       <Container size="lg" className="relative z-10 !pt-28 !pb-32 text-center">
         <h1 className="mx-auto max-w-5xl text-[2.1rem]/[1.16] md:text-[3.2rem]/[1.12] font-medium tracking-tight text-balance">
-          Sign on any chain, only by your rules.{' '}
+          Read any source. Decide in code.{' '}
           <br className="hidden md:inline" />
           <span className="text-lit-orange">
-            Keys no one can extract. Not even us.
+            Sign on any chain.
           </span>
         </h1>
         <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed">
-          Deploy your code once and the Lit Protocol runs it in a sealed TEE,
-          secured by the chain. No servers for you to run, no operator to trust.
+          Your code runs in secure hardware that holds the keys and signs only
+          when your rules pass. No servers to run. Keys no one can extract,
+          not even us.
         </p>
         <div className="mt-9 flex gap-3 justify-center flex-wrap">
           <Button
@@ -106,7 +107,7 @@ const LandingHero = () => {
             <Pillar label="READ" sub="Any API, any chain." />
             <PillarCenter
               label="DECIDE & SIGN"
-              sub="Your policy runs in the TEE. Keys sign only what it allows."
+              sub="Your policy runs in secure hardware. Keys sign only what it allows."
             />
             <Pillar label="WRITE" sub="Any EVM chain, Solana, Bitcoin, Cosmos." />
           </div>


### PR DESCRIPTION
Applies the "concrete mechanism over abstract category" principle to the hero — lead with **verbs**, not jargon nouns.

## Changes (`LandingHero.tsx`)
- **H1 → the read → decide → sign sequence:** "Read any source. Decide in code. **Sign on any chain.**" — mirrors the READ / DECIDE & SIGN / WRITE pillars right below it.
- **Subhead leads with the concrete mechanism + the recognized benefit:** "Your code runs in secure hardware that holds the keys and signs only when your rules pass. **Non-custodial**, with no servers to run. Keys no one can extract. Not even us." — "non-custodial" is accurate because owners can export their own keys, while no operator can extract them ("not even us"). Keeps the beloved proof line as the closing beat.
- **De-jargoned the DECIDE & SIGN pillar** (`TEE` → "secure hardware") so it doesn't re-introduce jargon three inches under a de-jargoned hero.

Everything else in the hero (CTAs, metrics, credibility row, pillars layout) is unchanged.

Preview: https://litprotocol-com-v2-git-hero-verbs-ab-lit-protocol.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)