### PR TITLE
Hero: tighten the subhead (deploy verifiably to compute and sign)

### DIFF
--- a/src/components/LandingHero/LandingHero.tsx
+++ b/src/components/LandingHero/LandingHero.tsx
@@ -48,10 +48,9 @@ const LandingHero = () => {
           The <span className="text-lit-orange">verifiable</span> integration
           layer for finance.
         </h1>
-        <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed text-pretty">
-          Read any source, enforce your policy in code, and settle on any
-          chain — inside confidential hardware that holds the keys and proves
-          exactly what ran. Non-custodial. Keys no one can extract, not even us.
+        <p className="mt-7 max-w-2xl mx-auto text-white/70 text-lg leading-relaxed text-balance">
+          Deploy software verifiably to compute and sign across DeFi,
+          centralized exchanges, and more.
         </p>
         <div className="mt-9 flex gap-3 justify-center flex-wrap">
           <Button


### PR DESCRIPTION
## What

Rewrites the hero subhead. The old one was crammed and fragment-y, and re-stated the READ/DECIDE/SETTLE pillars sitting right below it:

> ~~Read any source, enforce your policy in code, and settle on any chain — inside confidential hardware that holds the keys and proves exactly what ran. Non-custodial. Keys no one can extract, not even us.~~

New:

> **Deploy software verifiably to compute and sign across DeFi, centralized exchanges, and more.**

- Names the surface (DeFi + centralized exchanges) and the two actions (compute, sign) — complements the "verifiable integration layer for finance" headline.
- Drops the redundant read/decide/settle recitation (pillars cover it) and the bolted-on fragments (which also caused the "Non-/custodial" mid-word break).
- `text-balance` → two even lines, no orphan. Verified by measuring rendered line boxes at desktop (1280) and mobile (375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)